### PR TITLE
feat: add share button to export logs as text file

### DIFF
--- a/Ksign/Backend/Observable/LogsManager.swift
+++ b/Ksign/Backend/Observable/LogsManager.swift
@@ -44,6 +44,23 @@ final class LogsManager: ObservableObject {
 		DispatchQueue.main.async { self.entries.removeAll() }
 	}
 
+	func exportToText() -> String {
+		let dateFormatter = DateFormatter()
+		dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+		let timestamp = dateFormatter.string(from: Date())
+
+		var logText = "Ksign Logs Export\n"
+		logText += "Exported: \(timestamp)\n"
+		logText += "Total entries: \(entries.count)\n"
+		logText += String(repeating: "=", count: 30) + "\n\n"
+
+		for entry in entries {
+			logText += "\(entry.message)\n"
+		}
+
+		return logText
+	}
+
 	private func _redirect(fd: Int32, to pipe: Pipe) {
 		let handle = pipe.fileHandleForWriting
 		dup2(handle.fileDescriptor, fd)

--- a/Ksign/Views/Settings/Logs/LogsView.swift
+++ b/Ksign/Views/Settings/Logs/LogsView.swift
@@ -11,6 +11,7 @@ struct LogsView: View {
 	@ObservedObject var manager: LogsManager
 
 	private var _lastId: LogEntry.ID? { manager.entries.last?.id }
+	@State private var shareItems: [Any] = []
 
 	var body: some View {
 		NavigationStack {
@@ -35,6 +36,8 @@ struct LogsView: View {
 			}
 			.toolbar {
 				ToolbarItemGroup(placement: .navigationBarTrailing) {
+					Button { exportLogs() } label: { Image(systemName: "square.and.arrow.up") }
+						.disabled(manager.entries.isEmpty)
 					Button { manager.clear() } label: { Image(systemName: "trash") }
 					Button {
 						if manager.isCapturing { manager.stopCapture() } else { manager.startCapture() }
@@ -43,6 +46,25 @@ struct LogsView: View {
 					}
 				}
 			}
+		}
+	}
+
+	private func exportLogs() {
+		let logText = manager.exportToText()
+
+		let dateFormatter = DateFormatter()
+		dateFormatter.dateFormat = "yyyy-MM-dd-HHmmss"
+		let timestamp = dateFormatter.string(from: Date())
+		let fileName = "Ksign-Logs-\(timestamp).txt"
+
+		let tempDir = FileManager.default.temporaryDirectory
+		let fileURL = tempDir.appendingPathComponent(fileName)
+
+		do {
+			try logText.write(to: fileURL, atomically: true, encoding: .utf8)
+			UIActivityViewController.show(activityItems: [fileURL])
+		} catch {
+			print("Error exporting logs: \(error.localizedDescription)")
 		}
 	}
 }


### PR DESCRIPTION
Added share button in Logs view toolbar that allows users to export all log entries to a timestamped .txt file. This makes it easier for developers to gather feedback and debug issues reported by users.

The exported file includes a header with export timestamp and total entry count, followed by all log messages in a clean format.

Example:
<img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/1ac2a829-7779-4d6e-9132-2b83fac3f661" />
<img width="559" height="1062" alt="image" src="https://github.com/user-attachments/assets/1f63d557-7db8-4dc9-b7c4-abf4eb4f816d" />
