### PR TITLE
Add singular missing translation - german

### DIFF
--- a/Ksign/Resources/Localizable.xcstrings
+++ b/Ksign/Resources/Localizable.xcstrings
@@ -8315,8 +8315,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Root Dictionary"
+            "state" : "translated",
+            "value" : "Root-Liste"
           }
         },
         "vi" : {


### PR DESCRIPTION
Adds the new translation to KSign - german. Yes, this was neccesary