### PR TITLE
feat: Add support for .bundle files as tweaks (copy into .app)

### DIFF
--- a/Ksign/Extensions/UTType/UTType+tweak.swift
+++ b/Ksign/Extensions/UTType/UTType+tweak.swift
@@ -11,7 +11,9 @@ extension UTType {
 	static var dylib: UTType {
 		UTType(filenameExtension: "dylib")!
 	}
-	
+    static var bundle: UTType {
+        UTType(filenameExtension: "bundle")!
+    }
 	static var deb: UTType {
 		UTType(filenameExtension: "deb")!
 	}

--- a/Ksign/Utilities/Handlers/TweakHandler.swift
+++ b/Ksign/Utilities/Handlers/TweakHandler.swift
@@ -96,11 +96,22 @@ class TweakHandler {
 					try _fileManager.copyItem(at: url, to: destinationURL)
 				}
 				try await _handleDylib(framework: destinationURL)
-			default:
+            case "bundle":
+                try await _handleBundle(at: url)
+            default:
 				print("Unsupported file type: \(url.lastPathComponent), skipping.")
 			}
 		}
-		
+        
+        func _handleBundle(at url: URL) async throws {
+            let destinationURL = _app.appendingPathComponent(url.lastPathComponent)
+            
+            // Remove existing if present, then copy the whole bundle folder
+            if _fileManager.fileExists(atPath: destinationURL.path) {
+                try _fileManager.removeItem(at: destinationURL)
+            }
+            try _fileManager.copyItem(at: url, to: destinationURL)
+        }
 		// check contents of data.tar's extracted from debs
 		if !_directoriesToCheck.isEmpty {
 			try await _handleDirectories(at: _directoriesToCheck)

--- a/Ksign/Utilities/Handlers/TweakHandler.swift
+++ b/Ksign/Utilities/Handlers/TweakHandler.swift
@@ -58,6 +58,16 @@ class TweakHandler {
         }
     }
 
+    // MARK: - Bundle handling
+    private func _handleBundle(at url: URL) async throws {
+        let destinationURL = _app.appendingPathComponent(url.lastPathComponent)
+        
+        if _fileManager.fileExists(atPath: destinationURL.path) {
+            try _fileManager.removeItem(at: destinationURL)
+        }
+        try _fileManager.copyItem(at: url, to: destinationURL)
+    }
+    
 	public func getInputFiles() async throws {
 		print("DEBUG: getInputFiles called, URLs count: \(_urls.count)")
 		print("DEBUG: App path: \(_app.path)")
@@ -103,15 +113,6 @@ class TweakHandler {
 			}
 		}
         
-        func _handleBundle(at url: URL) async throws {
-            let destinationURL = _app.appendingPathComponent(url.lastPathComponent)
-            
-            // Remove existing if present, then copy the whole bundle folder
-            if _fileManager.fileExists(atPath: destinationURL.path) {
-                try _fileManager.removeItem(at: destinationURL)
-            }
-            try _fileManager.copyItem(at: url, to: destinationURL)
-        }
 		// check contents of data.tar's extracted from debs
 		if !_directoriesToCheck.isEmpty {
 			try await _handleDirectories(at: _directoriesToCheck)

--- a/Ksign/Views/Signing/SigningTweaksView.swift
+++ b/Ksign/Views/Signing/SigningTweaksView.swift
@@ -88,10 +88,10 @@ struct SigningTweaksView: View {
 			includingPropertiesForKeys: nil
 		) else { return }
 		
-		_tweaksInDirectory = files.filter { url in
-			let ext = url.pathExtension.lowercased()
-			return ext == "dylib" || ext == "deb" || ext == "framework"
-		}
+        _tweaksInDirectory = files.filter { url in
+            let ext = url.pathExtension.lowercased()
+            return ext == "dylib" || ext == "deb" || ext == "framework" || ext == "bundle"
+        }
 		
 		_enabledTweaks = Set(options.injectionFiles)
 	}
@@ -107,7 +107,7 @@ struct SigningTweaksView: View {
             return
         }
         
-        let allowedExtensions = Set(["dylib", "deb", "framework"])   
+        let allowedExtensions = Set(["dylib", "deb", "framework", "bundle"]) 
         
         for url in urls {
             let ext = url.pathExtension.lowercased()


### PR DESCRIPTION
- Extend SigningTweaksView to recognise .bundle files in the tweaks directory
- Allow importing .bundle files via the tweaks file picker
- Add TweakHandler._handleBundle(at:) to copy the whole bundle folder into the .app bundle
- Bundle files are placed at the root of the .app (e.g., Payload/App.app/BundleName.bundle)
- No Mach‑O injection is performed on .bundle files – only a copy
- (Optional) Update UTType+ipa.swift with .bundle uniform type identifier