### PR TITLE
feat: add .appex (App Extension) support for tweak injection

### DIFF
--- a/Ksign/Extensions/UTType/UTType+tweak.swift
+++ b/Ksign/Extensions/UTType/UTType+tweak.swift
@@ -21,4 +21,8 @@ extension UTType {
 	static var framework: UTType {
 		UTType(filenameExtension: "framework")!
 	}
+	
+	static var appex: UTType {
+		UTType(filenameExtension: "appex")!
+	}
 }

--- a/Ksign/Utilities/Handlers/TweakHandler.swift
+++ b/Ksign/Utilities/Handlers/TweakHandler.swift
@@ -85,6 +85,8 @@ class TweakHandler {
 				try await _handleFramework(at: url)
 			case "bundle":
 				try await _handleBundle(at: url)
+			case "appex":
+				try await _handleAppex(at: url)
 			default:
 				print("Unsupported file type: \(url.lastPathComponent), skipping.")
 			}
@@ -238,6 +240,21 @@ class TweakHandler {
 			try _fileManager.removeItem(at: destinationURL)
 		}
 		try _fileManager.copyItem(at: url, to: destinationURL)
+	}
+	
+	// Inject an .appex app extension into the PlugIns/ directory
+	private func _handleAppex(at url: URL) async throws {
+		let plugInsDir = _app.appendingPathComponent("PlugIns")
+		try _fileManager.createDirectoryIfNeeded(at: plugInsDir)
+		
+		let destinationURL = plugInsDir.appendingPathComponent(url.lastPathComponent)
+		
+		if _fileManager.fileExists(atPath: destinationURL.path) {
+			try _fileManager.removeItem(at: destinationURL)
+		}
+		try _fileManager.copyItem(at: url, to: destinationURL)
+		
+		print("Injected app extension: \(url.lastPathComponent) -> PlugIns/")
 	}
 	
 	// Read extracted deb file, locate all neccessary contents to copy over to the .app

--- a/Ksign/Views/Signing/SigningTweaksView.swift
+++ b/Ksign/Views/Signing/SigningTweaksView.swift
@@ -59,7 +59,7 @@ struct SigningTweaksView: View {
 					ContentUnavailableView {
 						Label(.localized("No Tweaks"), systemImage: "gear.badge.questionmark")
 					} description: {
-						Text(.localized("Importing your .dylib, .deb or .framework files \n These will also be automatically added to Tweaks folder"))
+						Text(.localized("Importing your .dylib, .deb, .framework or .appex files \n These will also be automatically added to Tweaks folder"))
                     } actions: {
 						Button {
 							_isAddingPresenting = true
@@ -68,7 +68,7 @@ struct SigningTweaksView: View {
 						}
 					}
 				} else {
-					Text(.localized("Importing your .dylib, .deb or .framework files \n These will also be automatically added to Tweaks folder"))
+					Text(.localized("Importing your .dylib, .deb, .framework or .appex files \n These will also be automatically added to Tweaks folder"))
 						.foregroundColor(.secondary)
 						.frame(maxWidth: .infinity, alignment: .center)
 						.padding()
@@ -107,7 +107,7 @@ struct SigningTweaksView: View {
 		
         _tweaksInDirectory = files.filter { url in
             let ext = url.pathExtension.lowercased()
-            return ext == "dylib" || ext == "deb" || ext == "framework" || ext == "bundle"
+            return ext == "dylib" || ext == "deb" || ext == "framework" || ext == "bundle" || ext == "appex"
         }
 		
 		_enabledTweaks = Set(options.injectionFiles)
@@ -124,7 +124,7 @@ struct SigningTweaksView: View {
             return
         }
         
-        let allowedExtensions = Set(["dylib", "deb", "framework", "bundle"]) 
+        let allowedExtensions = Set(["dylib", "deb", "framework", "bundle", "appex"]) 
         
         for url in urls {
             let ext = url.pathExtension.lowercased()


### PR DESCRIPTION
## Summary

Adds support for `.appex` (App Extension) files in Ksign’s tweak injection system.

## Changes

- **`UTType+tweak.swift`**
  - Added `UTType.appex` to recognize `.appex` file extensions.

- **`TweakHandler.swift`**
  - Added `_handleAppex(at:)` to copy `.appex` files into the app’s `PlugIns/` directory.
  - Ensures the `PlugIns/` directory is created when needed.
  - Removes any existing item before copying the new `.appex`.

- **`SigningTweaksView.swift`**
  - Updated UI labels to include `.appex`.
  - Updated file filter sets to support `.appex` alongside:
    - `.dylib`
    - `.deb`
    - `.framework`
    - `.bundle`
