### PR TITLE
feat: add source intelligence and unified jobs center

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -19,6 +19,7 @@ jobs:
 
       - name: Build
         run: |
+          make test
           make
 
       - name: Update Beta Release

--- a/Ksign.xcodeproj/project.pbxproj
+++ b/Ksign.xcodeproj/project.pbxproj
@@ -72,6 +72,11 @@
 			path = Ksign;
 			sourceTree = "<group>";
 		};
+		C0DE00012F00000000000001 /* KsignTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = KsignTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +125,7 @@
 			isa = PBXGroup;
 			children = (
 				3379C1BB2DA869A1004372DA /* Ksign */,
+				C0DE00012F00000000000001 /* KsignTests */,
 				3371F7302DA9ECDD00281AC6 /* Frameworks */,
 				3379C1BA2DA869A1004372DA /* Products */,
 			);
@@ -188,6 +194,9 @@
 			);
 			dependencies = (
 				AABA5D1E2DB3C87800BFCD2C /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				C0DE00012F00000000000001 /* KsignTests */,
 			);
 			name = KsignTests;
 			packageProductDependencies = (
@@ -578,7 +587,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_ENTITLEMENTS = "Feather/Supporting Files/Feather.entitlements";
+				CODE_SIGN_ENTITLEMENTS = "Ksign/Supporting Files/Feather.entitlements";
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
@@ -589,7 +598,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = thewonderofyou.FeatherTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SDKROOT = iphoneos;
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -601,7 +611,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_ENTITLEMENTS = "Feather/Supporting Files/Feather.entitlements";
+				CODE_SIGN_ENTITLEMENTS = "Ksign/Supporting Files/Feather.entitlements";
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
@@ -612,7 +622,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = thewonderofyou.FeatherTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SDKROOT = iphoneos;
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Ksign/Backend/Observable/DownloadManager.swift
+++ b/Ksign/Backend/Observable/DownloadManager.swift
@@ -45,6 +45,7 @@ class Download: Identifiable, @unchecked Sendable, ObservableObject {
 	let url: URL
 	let fileName: String
 	let onlyArchiving: Bool
+	var jobID: String { "download.\(id)" }
     
     init(
 		id: String,
@@ -98,6 +99,21 @@ class DownloadManager: NSObject, ObservableObject {
         
         let task = _session.downloadTask(with: url)
         download.task = task
+		task.taskDescription = id
+		JobsManager.shared.start(
+			kind: .download,
+			title: download.fileName,
+			detail: .localized("Downloading"),
+			sourceURL: url,
+			id: download.jobID,
+			cancel: { [weak self, weak download] in
+				guard let download else { return }
+				self?.cancelDownload(download, updateJob: false)
+			},
+			retry: { [weak self] in
+				_ = self?.startDownload(from: url, id: id)
+			}
+		)
         task.resume()
         
         downloads.append(download)
@@ -114,12 +130,20 @@ class DownloadManager: NSObject, ObservableObject {
 		id: String = UUID().uuidString
 	) -> Download {
 		let download = Download(id: id, url: url, onlyArchiving: true)
+		JobsManager.shared.start(
+			kind: .importApp,
+			title: url.lastPathComponent,
+			detail: .localized("Importing"),
+			sourceURL: url,
+			id: download.jobID
+		)
 		downloads.append(download)
 		_updateBackgroundAudioState()
 		return download
 	}
     
     func resumeDownload(_ download: Download) {
+		JobsManager.shared.update(download.jobID, detail: .localized("Downloading"), state: .running)
         if let resumeData = download.resumeData {
             let task = _session.downloadTask(withResumeData: resumeData)
             download.task = task
@@ -133,7 +157,11 @@ class DownloadManager: NSObject, ObservableObject {
         }
     }
     
-    func cancelDownload(_ download: Download) {
+    func cancelDownload(_ download: Download, updateJob: Bool = true) {
+		if updateJob {
+			JobsManager.shared.cancel(download.jobID)
+			return
+		}
         download.task?.cancel()
         
         if let index = downloads.firstIndex(where: { $0.id == download.id }) {
@@ -150,15 +178,22 @@ class DownloadManager: NSObject, ObservableObject {
 	}
 	
 	func getDownload(by id: String) -> Download? {
-		return downloads.first(where: { $0.id == id })
+		_onMain { downloads.first(where: { $0.id == id }) }
 	}
 	
 	func getDownloadIndex(by id: String) -> Int? {
-		return downloads.firstIndex(where: { $0.id == id })
+		_onMain { downloads.firstIndex(where: { $0.id == id }) }
 	}
 	
 	func getDownloadTask(by task: URLSessionDownloadTask) -> Download? {
-		return downloads.first(where: { $0.task == task })
+		_onMain { downloads.first(where: { $0.task == task }) }
+	}
+
+	private func _onMain<T>(_ operation: () -> T) -> T {
+		if Thread.isMainThread {
+			return operation()
+		}
+		return DispatchQueue.main.sync(execute: operation)
 	}
 }
 
@@ -191,9 +226,18 @@ extension DownloadManager: URLSessionDownloadDelegate {
 			DispatchQueue.main.async {
 				if let dl = dl, let index = DownloadManager.shared.getDownloadIndex(by: dl.id) {
 					DownloadManager.shared.downloads.remove(at: index)
+					DownloadManager.shared._updateBackgroundAudioState()
+					if #available(iOS 26.0, *) {
+						BackgroundTaskManager.shared.stopTask(for: dl.id, success: err == nil)
+					}
 				}
 				if err == nil {
 					self._notifyDownloadCompleted(fileName: url.lastPathComponent)
+					if let dl {
+						JobsManager.shared.complete(dl.jobID, detail: .localized("Imported to Library"))
+					}
+				} else if let dl, let err {
+					JobsManager.shared.fail(dl.jobID, error: err, detail: .localized("Import failed"))
 				}
 				completion(err)
 			}
@@ -225,10 +269,13 @@ extension DownloadManager: URLSessionDownloadDelegate {
 		
 		do {
 			try FileManager.default.createDirectoryIfNeeded(at: downloadDir)
-			let suggestedFileName = downloadTask.response?.suggestedFilename ?? download.fileName
+			let suggestedFileName = URL(
+				fileURLWithPath: downloadTask.response?.suggestedFilename ?? download.fileName
+			).lastPathComponent
 			let destinationURL = downloadDir.appendingPathComponent(suggestedFileName)
 			try FileManager.default.removeFileIfNeeded(at: destinationURL)
 			try FileManager.default.moveItem(at: location, to: destinationURL)
+			JobsManager.shared.update(download.jobID, progress: 0.7, detail: .localized("Importing"))
 			self.handlePachageFile(url: destinationURL, dl: download) { err in
 				if let error = err {
 					print("Error handling downloaded file: \(error.localizedDescription)")
@@ -236,6 +283,16 @@ extension DownloadManager: URLSessionDownloadDelegate {
 			}
 		} catch {
 			print("Error handling downloaded file: \(error.localizedDescription)")
+			JobsManager.shared.fail(download.jobID, error: error, detail: .localized("Download failed"))
+			DispatchQueue.main.async {
+				if let index = self.getDownloadIndex(by: download.id) {
+					self.downloads.remove(at: index)
+				}
+				self._updateBackgroundAudioState()
+				if #available(iOS 26.0, *) {
+					BackgroundTaskManager.shared.stopTask(for: download.id, success: false)
+				}
+			}
 		}
 	}
     
@@ -248,6 +305,11 @@ extension DownloadManager: URLSessionDownloadDelegate {
 			: 0
             download.bytesDownloaded = totalBytesWritten
             download.totalBytes = totalBytesExpectedToWrite
+			JobsManager.shared.update(
+				download.jobID,
+				progress: download.overallProgress,
+				detail: download.progressText
+			)
             if #available(iOS 26.0, *) {
                 BackgroundTaskManager.shared.updateProgress(for: download.id, progress: download.overallProgress)
             }
@@ -266,6 +328,13 @@ extension DownloadManager: URLSessionDownloadDelegate {
 		DispatchQueue.main.async {
 			if let index = self.getDownloadIndex(by: download.id) {
 				self.downloads.remove(at: index)
+			}
+			self._updateBackgroundAudioState()
+			if #available(iOS 26.0, *) {
+				BackgroundTaskManager.shared.stopTask(for: download.id, success: false)
+			}
+			if let error, (error as NSError).code != NSURLErrorCancelled {
+				JobsManager.shared.fail(download.jobID, error: error, detail: .localized("Download failed"))
 			}
 		}
     }

--- a/Ksign/Backend/Observable/ExtractManager.swift
+++ b/Ksign/Backend/Observable/ExtractManager.swift
@@ -12,6 +12,7 @@ final class ExtractItem: ObservableObject, Identifiable {
 	@Published var progress: Double = 0.0
 	let id: String
 	let fileName: String
+	var jobID: String { "extract.\(id)" }
 
 	init(id: String = UUID().uuidString, fileName: String) {
 		self.id = id
@@ -29,6 +30,12 @@ final class ExtractManager: ObservableObject {
 	@discardableResult
 	func start(fileName: String) -> ExtractItem {
 		let item = ExtractItem(fileName: fileName)
+		JobsManager.shared.start(
+			kind: .extraction,
+			title: fileName,
+			detail: .localized("Extracting"),
+			id: item.jobID
+		)
 		DispatchQueue.main.async {
 			self.extractItems.append(item)
 		}
@@ -39,13 +46,19 @@ final class ExtractManager: ObservableObject {
 		let clamped = max(0.0, min(1.0, progress))
 		DispatchQueue.main.async {
 			item.progress = clamped
+			JobsManager.shared.update(item.jobID, progress: clamped, detail: .localized("Extracting"))
 		}
 	}
 
-	func finish(item: ExtractItem) {
+	func finish(item: ExtractItem, error: Error? = nil) {
 		DispatchQueue.main.async {
 			if let idx = self.extractItems.firstIndex(where: { $0.id == item.id }) {
 				self.extractItems.remove(at: idx)
+			}
+			if let error {
+				JobsManager.shared.fail(item.jobID, error: error, detail: .localized("Extraction failed"))
+			} else {
+				JobsManager.shared.complete(item.jobID, detail: .localized("Extraction completed"))
 			}
 		}
 	}

--- a/Ksign/Backend/Observable/JobsManager.swift
+++ b/Ksign/Backend/Observable/JobsManager.swift
@@ -1,0 +1,289 @@
+import Combine
+import Foundation
+
+enum JobKind: String, Codable, CaseIterable {
+	case download
+	case importApp
+	case signing
+	case extraction
+	case archive
+	case installation
+	case sourceRefresh
+	case certificateImport
+
+	var title: String {
+		switch self {
+		case .download: return .localized("Download")
+		case .importApp: return .localized("Import")
+		case .signing: return .localized("Signing")
+		case .extraction: return .localized("Extraction")
+		case .archive: return .localized("Archive")
+		case .installation: return .localized("Installation")
+		case .sourceRefresh: return .localized("Source Refresh")
+		case .certificateImport: return .localized("Certificate Import")
+		}
+	}
+
+	var icon: String {
+		switch self {
+		case .download: return "arrow.down.circle"
+		case .importApp: return "square.and.arrow.down"
+		case .signing: return "signature"
+		case .extraction: return "archivebox"
+		case .archive: return "doc.zipper"
+		case .installation: return "arrow.down.app"
+		case .sourceRefresh: return "arrow.triangle.2.circlepath"
+		case .certificateImport: return "person.text.rectangle"
+		}
+	}
+}
+
+enum JobState: String, Codable {
+	case queued
+	case running
+	case completed
+	case failed
+	case cancelled
+
+	var isFinished: Bool {
+		switch self {
+		case .completed, .failed, .cancelled: return true
+		case .queued, .running: return false
+		}
+	}
+}
+
+struct JobRecord: Identifiable, Codable, Equatable {
+	let id: String
+	let kind: JobKind
+	var title: String
+	var detail: String
+	var progress: Double
+	var state: JobState
+	var errorMessage: String?
+	var sourceURL: URL?
+	let createdAt: Date
+	var updatedAt: Date
+	var finishedAt: Date?
+}
+
+final class JobsManager: ObservableObject {
+	static let shared = JobsManager()
+
+	@Published private(set) var jobs: [JobRecord] = []
+
+	private let _storageKey = "ksign.jobs.history.v1"
+	private let _historyLimit = 100
+	private var _cancelActions: [String: () -> Void] = [:]
+	private var _retryActions: [String: () -> Void] = [:]
+	private var _persistWorkItem: DispatchWorkItem?
+
+	private init() {
+		if
+			let data = UserDefaults.standard.data(forKey: _storageKey),
+			let decoded = try? JSONDecoder().decode([JobRecord].self, from: data)
+		{
+			jobs = decoded.map { job in
+				guard !job.state.isFinished else { return job }
+				var interrupted = job
+				interrupted.state = .failed
+				interrupted.detail = .localized("Interrupted when Ksign closed")
+				interrupted.errorMessage = .localized("The operation did not finish.")
+				interrupted.finishedAt = Date()
+				interrupted.updatedAt = Date()
+				return interrupted
+			}
+			_persist()
+		}
+	}
+
+	var activeJobs: [JobRecord] {
+		jobs
+			.filter { !$0.state.isFinished }
+			.sorted { $0.createdAt > $1.createdAt }
+	}
+
+	var recentJobs: [JobRecord] {
+		jobs
+			.filter { $0.state.isFinished }
+			.sorted { $0.updatedAt > $1.updatedAt }
+	}
+
+	@discardableResult
+	func start(
+		kind: JobKind,
+		title: String,
+		detail: String = "",
+		sourceURL: URL? = nil,
+		id: String = UUID().uuidString,
+		cancel: (() -> Void)? = nil,
+		retry: (() -> Void)? = nil
+	) -> String {
+		_mutate {
+			let now = Date()
+			let job = JobRecord(
+				id: id,
+				kind: kind,
+				title: title,
+				detail: detail,
+				progress: 0,
+				state: .running,
+				errorMessage: nil,
+				sourceURL: sourceURL,
+				createdAt: now,
+				updatedAt: now,
+				finishedAt: nil
+			)
+			self.jobs.removeAll { $0.id == id }
+			self.jobs.append(job)
+			self._cancelActions[id] = cancel
+			self._retryActions[id] = retry
+			self._trimAndPersist()
+		}
+		return id
+	}
+
+	func update(
+		_ id: String,
+		progress: Double? = nil,
+		detail: String? = nil,
+		state: JobState? = nil
+	) {
+		_mutate {
+			guard let index = self.jobs.firstIndex(where: { $0.id == id }) else { return }
+			guard !self.jobs[index].state.isFinished else { return }
+			if let progress {
+				self.jobs[index].progress = max(0, min(1, progress))
+			}
+			if let detail {
+				self.jobs[index].detail = detail
+			}
+			if let state {
+				self.jobs[index].state = state
+			}
+			self.jobs[index].updatedAt = Date()
+			self._schedulePersist()
+		}
+	}
+
+	func complete(_ id: String, detail: String = "") {
+		_finish(id, state: .completed, detail: detail, error: nil)
+	}
+
+	func fail(_ id: String, error: Error, detail: String = "") {
+		_finish(id, state: .failed, detail: detail, error: error.localizedDescription)
+	}
+
+	func fail(_ id: String, message: String, detail: String = "") {
+		_finish(id, state: .failed, detail: detail, error: message)
+	}
+
+	func cancel(_ id: String) {
+		_mutate {
+			self._cancelActions[id]?()
+			self._finishOnMain(id, state: .cancelled, detail: .localized("Cancelled"), error: nil)
+		}
+	}
+
+	@discardableResult
+	func retry(_ id: String) -> Bool {
+		var didRetry = false
+		_mutate {
+			guard let retry = self._retryActions[id] else { return }
+			didRetry = true
+			retry()
+		}
+		return didRetry
+	}
+
+	func canCancel(_ id: String) -> Bool {
+		_cancelActions[id] != nil
+	}
+
+	func canRetry(_ id: String) -> Bool {
+		_retryActions[id] != nil
+	}
+
+	func clearFinished() {
+		_mutate {
+			let finishedIDs = Set(self.jobs.filter { $0.state.isFinished }.map(\.id))
+			self.jobs.removeAll { $0.state.isFinished }
+			self._cancelActions = self._cancelActions.filter { !finishedIDs.contains($0.key) }
+			self._retryActions = self._retryActions.filter { !finishedIDs.contains($0.key) }
+			self._trimAndPersist()
+		}
+	}
+
+	func clearAll() {
+		_mutate {
+			let cancelActions = Array(self._cancelActions.values)
+			self.jobs.removeAll()
+			self._cancelActions.removeAll()
+			self._retryActions.removeAll()
+			self._trimAndPersist()
+			cancelActions.forEach { $0() }
+		}
+	}
+
+	private func _finish(_ id: String, state: JobState, detail: String, error: String?) {
+		_mutate {
+			self._finishOnMain(id, state: state, detail: detail, error: error)
+		}
+	}
+
+	private func _finishOnMain(_ id: String, state: JobState, detail: String, error: String?) {
+		guard let index = jobs.firstIndex(where: { $0.id == id }) else { return }
+		guard !jobs[index].state.isFinished else { return }
+		jobs[index].state = state
+		jobs[index].progress = state == .completed ? 1 : jobs[index].progress
+		if !detail.isEmpty {
+			jobs[index].detail = detail
+		}
+		jobs[index].errorMessage = error
+		jobs[index].updatedAt = Date()
+		jobs[index].finishedAt = Date()
+		_cancelActions[id] = nil
+		if state == .completed {
+			_retryActions[id] = nil
+		}
+		_trimAndPersist()
+	}
+
+	private func _mutate(_ operation: @escaping () -> Void) {
+		if Thread.isMainThread {
+			operation()
+		} else {
+			DispatchQueue.main.sync(execute: operation)
+		}
+	}
+
+	private func _trimAndPersist() {
+		_persistWorkItem?.cancel()
+		_persistWorkItem = nil
+		let active = jobs.filter { !$0.state.isFinished }
+		let finished = jobs
+			.filter { $0.state.isFinished }
+			.sorted { $0.updatedAt > $1.updatedAt }
+			.prefix(_historyLimit)
+		jobs = active + finished
+		let retainedIDs = Set(jobs.map(\.id))
+		_cancelActions = _cancelActions.filter { retainedIDs.contains($0.key) }
+		_retryActions = _retryActions.filter { retainedIDs.contains($0.key) }
+		_persist()
+	}
+
+	private func _schedulePersist() {
+		_persistWorkItem?.cancel()
+		let workItem = DispatchWorkItem { [weak self] in
+			self?._persistWorkItem = nil
+			self?._persist()
+		}
+		_persistWorkItem = workItem
+		DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: workItem)
+	}
+
+	private func _persist() {
+		guard let data = try? JSONEncoder().encode(jobs) else { return }
+		UserDefaults.standard.set(data, forKey: _storageKey)
+	}
+}

--- a/Ksign/Backend/Observable/OptionsManager.swift
+++ b/Ksign/Backend/Observable/OptionsManager.swift
@@ -17,12 +17,31 @@ class OptionsManager: ObservableObject {
 	
 	init() {
 		if let data = UserDefaults.standard.data(forKey: _key),
-		   let savedOptions = try? JSONDecoder().decode(Options.self, from: data) {
+		   let savedOptions = Self.decodeOptionsMergingDefaults(data) {
 			self.options = savedOptions
 		} else {
 			self.options = Options.defaultOptions
 			self.saveOptions()
 		}
+	}
+
+	static func decodeOptionsMergingDefaults(_ savedData: Data) -> Options? {
+		guard
+			let defaultsData = try? JSONEncoder().encode(Options.defaultOptions),
+			let defaults = try? JSONSerialization.jsonObject(with: defaultsData) as? [String: Any],
+			let saved = try? JSONSerialization.jsonObject(with: savedData) as? [String: Any]
+		else {
+			return nil
+		}
+
+		let merged = defaults.merging(saved) { _, savedValue in savedValue }
+		guard
+			let mergedData = try? JSONSerialization.data(withJSONObject: merged),
+			let options = try? JSONDecoder().decode(Options.self, from: mergedData)
+		else {
+			return nil
+		}
+		return options
 	}
 	
 	/// Saves options

--- a/Ksign/Backend/Observable/SourceIntelligenceManager.swift
+++ b/Ksign/Backend/Observable/SourceIntelligenceManager.swift
@@ -1,0 +1,281 @@
+import AltSourceKit
+import Combine
+import CoreData
+import CryptoKit
+import Foundation
+
+enum SourceHealth: String, Codable {
+	case unchecked
+	case healthy
+	case degraded
+	case offline
+
+	var title: String {
+		switch self {
+		case .unchecked: return .localized("Unchecked")
+		case .healthy: return .localized("Healthy")
+		case .degraded: return .localized("Degraded")
+		case .offline: return .localized("Offline")
+		}
+	}
+
+	var icon: String {
+		switch self {
+		case .unchecked: return "questionmark.circle"
+		case .healthy: return "checkmark.circle.fill"
+		case .degraded: return "exclamationmark.triangle.fill"
+		case .offline: return "xmark.octagon.fill"
+		}
+	}
+}
+
+enum SourceTrust: String, Codable {
+	case unknown
+	case trusted
+	case untrusted
+
+	var title: String {
+		switch self {
+		case .unknown: return .localized("Unreviewed")
+		case .trusted: return .localized("Trusted")
+		case .untrusted: return .localized("Untrusted")
+		}
+	}
+
+	var icon: String {
+		switch self {
+		case .unknown: return "questionmark.shield"
+		case .trusted: return "checkmark.shield.fill"
+		case .untrusted: return "xmark.shield.fill"
+		}
+	}
+}
+
+struct SourceInsight: Codable, Equatable {
+	var isFavorite = false
+	var trust: SourceTrust = .unknown
+	var health: SourceHealth = .unchecked
+	var lastChecked: Date?
+	var lastSuccessfulFetch: Date?
+	var lastError: String?
+	var consecutiveFailures = 0
+	var appCount = 0
+	var updateCount = 0
+	var fingerprint: String?
+	var contentChanged = false
+}
+
+final class SourceIntelligenceManager: ObservableObject {
+	static let shared = SourceIntelligenceManager()
+
+	@Published private(set) var insights: [String: SourceInsight] = [:]
+	@Published private(set) var updateBundleIDs: Set<String> = []
+
+	private let _storageKey = "ksign.source.intelligence.v1"
+	private let _updatesStorageKey = "ksign.source.intelligence.updates.v1"
+	private var _updatesBySource: [String: Set<String>] = [:]
+	private var _localVersions: [String: [String]] = [:]
+	private var _hasLocalVersionSnapshot = false
+
+	private init() {
+		if
+			let data = UserDefaults.standard.data(forKey: _storageKey),
+			let decoded = try? JSONDecoder().decode([String: SourceInsight].self, from: data)
+		{
+			insights = decoded
+		}
+		if
+			let data = UserDefaults.standard.data(forKey: _updatesStorageKey),
+			let decoded = try? JSONDecoder().decode([String: Set<String>].self, from: data)
+		{
+			_updatesBySource = decoded
+			_refreshUpdateBundleIDs()
+		}
+	}
+
+	func key(for source: AltSource) -> String {
+		source.identifier
+	}
+
+	func insight(for source: AltSource) -> SourceInsight {
+		if let stored = insights[key(for: source)] {
+			return stored
+		}
+		var initial = SourceInsight()
+		if source.isBuiltIn {
+			initial.trust = .trusted
+		}
+		return initial
+	}
+
+	func toggleFavorite(_ source: AltSource) {
+		_update(source) { $0.isFavorite.toggle() }
+	}
+
+	func setTrust(_ trust: SourceTrust, for source: AltSource) {
+		_update(source) { $0.trust = trust }
+	}
+
+	func remove(_ source: AltSource) {
+		let sourceKey = key(for: source)
+		insights[sourceKey] = nil
+		_updatesBySource[sourceKey] = nil
+		_refreshUpdateBundleIDs()
+		_persist()
+	}
+
+	func clearAll() {
+		insights.removeAll()
+		_updatesBySource.removeAll()
+		_localVersions.removeAll()
+		_hasLocalVersionSnapshot = false
+		updateBundleIDs.removeAll()
+		UserDefaults.standard.removeObject(forKey: _storageKey)
+		UserDefaults.standard.removeObject(forKey: _updatesStorageKey)
+	}
+
+	func prepareForRefresh() {
+		_localVersions = _readLocalVersions()
+		_hasLocalVersionSnapshot = true
+	}
+
+	func invalidateLocalVersionSnapshot() {
+		_localVersions.removeAll()
+		_hasLocalVersionSnapshot = false
+		objectWillChange.send()
+	}
+
+	func recordSuccess(source: AltSource, repository: ASRepository) {
+		let sourceKey = key(for: source)
+		let fingerprint = _fingerprint(repository)
+		let updateIDs = _updateIDs(in: repository)
+
+		_updatesBySource[sourceKey] = updateIDs
+		_refreshUpdateBundleIDs()
+
+		_update(source) { insight in
+			insight.contentChanged = insight.fingerprint != nil && insight.fingerprint != fingerprint
+			insight.fingerprint = fingerprint
+			insight.health = .healthy
+			insight.lastChecked = Date()
+			insight.lastSuccessfulFetch = Date()
+			insight.lastError = nil
+			insight.consecutiveFailures = 0
+			insight.appCount = repository.apps.count
+			insight.updateCount = updateIDs.count
+		}
+	}
+
+	func recordFailure(source: AltSource, error: Error) {
+		recordFailure(source: source, message: error.localizedDescription)
+	}
+
+	func recordFailure(source: AltSource, message: String) {
+		_update(source) { insight in
+			insight.lastChecked = Date()
+			insight.lastError = message
+			insight.consecutiveFailures += 1
+			insight.health = insight.consecutiveFailures >= 3 ? .offline : .degraded
+		}
+	}
+
+	func isUpdateAvailable(for app: ASRepository.App) -> Bool {
+		guard
+			let id = app.id,
+			let currentVersion = app.currentVersion,
+			updateBundleIDs.contains(id)
+		else {
+			return false
+		}
+
+		if !_hasLocalVersionSnapshot {
+			prepareForRefresh()
+		}
+		guard let installed = _localVersions[id] else { return false }
+		return Self.isNewerVersion(currentVersion, than: installed)
+	}
+
+	static func isNewerVersion(_ candidate: String, than installedVersions: [String]) -> Bool {
+		guard !installedVersions.isEmpty else { return false }
+		return installedVersions.allSatisfy {
+			candidate.compare($0, options: [.numeric, .caseInsensitive]) == .orderedDescending
+		}
+	}
+
+	private func _update(_ source: AltSource, operation: (inout SourceInsight) -> Void) {
+		let sourceKey = key(for: source)
+		var insight = insight(for: source)
+		operation(&insight)
+		insights[sourceKey] = insight
+		_persist()
+	}
+
+	private func _refreshUpdateBundleIDs() {
+		updateBundleIDs = _updatesBySource.values.reduce(into: Set<String>()) {
+			$0.formUnion($1)
+		}
+	}
+
+	private func _updateIDs(in repository: ASRepository) -> Set<String> {
+		let localVersions = _hasLocalVersionSnapshot ? _localVersions : _readLocalVersions()
+
+		return Set(repository.apps.compactMap { app in
+			guard
+				let id = app.id,
+				let currentVersion = app.currentVersion,
+				let installed = localVersions[id],
+				Self.isNewerVersion(currentVersion, than: installed)
+			else {
+				return nil
+			}
+			return id
+		})
+	}
+
+	private func _readLocalVersions() -> [String: [String]] {
+		let importedRequest: NSFetchRequest<Imported> = Imported.fetchRequest()
+		let signedRequest: NSFetchRequest<Signed> = Signed.fetchRequest()
+		var versions: [String: [String]] = [:]
+
+		Storage.shared.context.performAndWait {
+			let imported: [AppInfoPresentable] = ((try? Storage.shared.context.fetch(importedRequest)) ?? [])
+				.map { $0 as AppInfoPresentable }
+			let signed: [AppInfoPresentable] = ((try? Storage.shared.context.fetch(signedRequest)) ?? [])
+				.map { $0 as AppInfoPresentable }
+			let localApps = imported + signed
+
+			versions = Dictionary(grouping: localApps.compactMap { app -> (String, String)? in
+				guard let id = app.identifier, let version = app.version else { return nil }
+				return (id, version)
+			}, by: { $0.0 }).mapValues { $0.map { $0.1 } }
+		}
+
+		return versions
+	}
+
+	private func _fingerprint(_ repository: ASRepository) -> String {
+		let contents = repository.apps
+			.map {
+				[
+					$0.id ?? "",
+					$0.currentVersion ?? "",
+					$0.currentDownloadUrl?.absoluteString ?? ""
+				].joined(separator: "|")
+			}
+			.sorted()
+			.joined(separator: "\n")
+		return SHA256.hash(data: Data(contents.utf8))
+			.map { String(format: "%02x", $0) }
+			.joined()
+	}
+
+	private func _persist() {
+		let encoder = JSONEncoder()
+		if let data = try? encoder.encode(insights) {
+			UserDefaults.standard.set(data, forKey: _storageKey)
+		}
+		if let data = try? encoder.encode(_updatesBySource) {
+			UserDefaults.standard.set(data, forKey: _updatesStorageKey)
+		}
+	}
+}

--- a/Ksign/Backend/Server/ServerInstaller+Compute.swift
+++ b/Ksign/Backend/Server/ServerInstaller+Compute.swift
@@ -12,36 +12,24 @@ import UIKit.UIGraphicsImageRenderer
 
 extension ServerInstaller {
 	var plistEndpoint: URL {
-		var comps = URLComponents()
-		comps.scheme = ServerInstaller.getServerMethod() == 1 ? "http" : "https"
-		comps.host = Self.sni
-		comps.path = "/\(id).plist"
-		comps.port = port
-		return comps.url!
+		_endpoint(path: "/\(id).plist")
 	}
 
 	var payloadEndpoint: URL {
-		var comps = URLComponents()
-		comps.scheme = ServerInstaller.getServerMethod() == 1 ? "http" : "https"
-		comps.host = Self.sni
-		comps.path = "/\(id).ipa"
-		comps.port = port
-		return comps.url!
+		_endpoint(path: "/\(id).ipa")
 	}
 	
 	var pageEndpoint: URL {
-		var comps = URLComponents()
-		comps.scheme = ServerInstaller.getServerMethod() == 1 ? "http" : "https"
-		comps.host = Self.sni
-		comps.path = "/install"
-		comps.port = port
-		return comps.url!
+		_endpoint(path: "/install")
 	}
 	
 	var externalServerLink: String {
-		let baseUrl = "https://api.palera.in/genPlist?bundleid=\(app.identifier!)&name=\(app.name!)&version=\(app.version!)&fetchurl=\(self.payloadEndpoint.absoluteString)"
-		let encodedBaseUrl = baseUrl.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
-		let finalEncodedUrl = encodedBaseUrl.addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
+		let bundleID = appIdentifier ?? "unknown"
+		let name = appName ?? "Unknown"
+		let version = appVersion ?? "0"
+		let baseUrl = "https://api.palera.in/genPlist?bundleid=\(bundleID)&name=\(name)&version=\(version)&fetchurl=\(self.payloadEndpoint.absoluteString)"
+		let encodedBaseUrl = baseUrl.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? baseUrl
+		let finalEncodedUrl = encodedBaseUrl.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? encodedBaseUrl
 		
 		return finalEncodedUrl
 	}
@@ -59,21 +47,20 @@ extension ServerInstaller {
 	}
 
 	var displayImageSmallEndpoint: URL {
-		var comps = URLComponents()
-		comps.scheme = "https"
-		comps.host = Self.sni
-		comps.path = "/app57x57.png"
-		comps.port = port
-		return comps.url!
+		_endpoint(path: "/app57x57.png", scheme: "https")
 	}
 
 	var displayImageLargeEndpoint: URL {
+		_endpoint(path: "/app512x512.png", scheme: "https")
+	}
+
+	private func _endpoint(path: String, scheme: String? = nil) -> URL {
 		var comps = URLComponents()
-		comps.scheme = "https"
+		comps.scheme = scheme ?? (ServerInstaller.getServerMethod() == 1 ? "http" : "https")
 		comps.host = Self.sni
-		comps.path = "/app512x512.png"
+		comps.path = path
 		comps.port = port
-		return comps.url!
+		return comps.url ?? URL(fileURLWithPath: path)
 	}
 	
 	var displayImageSmallData: Data {
@@ -90,7 +77,7 @@ extension ServerInstaller {
 			UIColor.accent.setFill()
 			ctx.fill(.init(x: 0, y: 0, width: r, height: r))
 		}
-		return image.pngData()!
+		return image.pngData() ?? Data()
 	}
 
 	var html: String {
@@ -114,10 +101,10 @@ extension ServerInstaller {
 				],
 			],
 			"metadata": [
-				"bundle-identifier": app.identifier,
-				"bundle-version": app.version,
+				"bundle-identifier": appIdentifier ?? "unknown",
+				"bundle-version": appVersion ?? "0",
 				"kind": "software",
-				"title": app.name,
+				"title": appName ?? "Unknown",
 			],
 		],],
 	]}

--- a/Ksign/Backend/Server/ServerInstaller+TLS.swift
+++ b/Ksign/Backend/Server/ServerInstaller+TLS.swift
@@ -16,30 +16,36 @@ import SystemConfiguration.CaptiveNetwork
 // MARK: - Class extension: TLS/Setup
 extension ServerInstaller {
 	// MARK: Setup
-	private static let env: Environment = {
-		var env = try! Environment.detect()
-		try! LoggingSystem.bootstrap(from: &env)
-		return env
-	}()
+	private static let environmentResult: Result<Environment, Error> = Result {
+		var environment = try Environment.detect()
+		try LoggingSystem.bootstrap(from: &environment)
+		return environment
+	}
 	
 	static func setupApp(port: Int) throws -> Application {
-		let app = Application(env)
-		app.threadPool = .init(numberOfThreads: 1)
-		
-		if ServerInstaller.getServerMethod() != 1 {
-			if let tls = try Self.tls() {
+		let app = Application(try environmentResult.get())
+		do {
+			app.threadPool = .init(numberOfThreads: 1)
+
+			if ServerInstaller.getServerMethod() != 1 {
+				guard let tls = try Self.tls() else {
+					throw ServerInstallerError.missingTLSCredentials
+				}
 				app.http.server.configuration.tlsConfiguration = tls
 			}
+
+			app.http.server.configuration.hostname = Self.sni
+			app.http.server.configuration.tcpNoDelay = true
+			app.http.server.configuration.address = .hostname("0.0.0.0", port: port)
+			app.http.server.configuration.port = port
+			app.routes.defaultMaxBodySize = "128mb"
+			app.routes.caseInsensitive = false
+
+			return app
+		} catch {
+			app.shutdown()
+			throw error
 		}
-		
-		app.http.server.configuration.hostname = Self.sni
-		app.http.server.configuration.tcpNoDelay = true
-		app.http.server.configuration.address = .hostname("0.0.0.0", port: port)
-		app.http.server.configuration.port = port
-		app.routes.defaultMaxBodySize = "128mb"
-		app.routes.caseInsensitive = false
-		
-		return app
 	}
 	
 	// MARK: Files/IP
@@ -111,9 +117,13 @@ extension ServerInstaller {
 		
 		if getifaddrs(&ifaddr) == 0 {
 			var ptr = ifaddr
-			while ptr != nil {
-				let interface = ptr!.pointee
-				let addrFamily = interface.ifa_addr.pointee.sa_family
+			while let pointer = ptr {
+				let interface = pointer.pointee
+				guard let interfaceAddress = interface.ifa_addr else {
+					ptr = interface.ifa_next
+					continue
+				}
+				let addrFamily = interfaceAddress.pointee.sa_family
 				
 				if addrFamily == UInt8(AF_INET) {
 					
@@ -121,7 +131,7 @@ extension ServerInstaller {
 					if name == "en0" || name == "pdp_ip0" {
 						
 						var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
-						if getnameinfo(interface.ifa_addr, socklen_t(interface.ifa_addr.pointee.sa_len),
+						if getnameinfo(interfaceAddress, socklen_t(interfaceAddress.pointee.sa_len),
 									   &hostname, socklen_t(hostname.count),
 									   nil, socklen_t(0), NI_NUMERICHOST) == 0 {
 							address = String(cString: hostname)
@@ -129,7 +139,7 @@ extension ServerInstaller {
 						
 					}
 				}
-				ptr = ptr!.pointee.ifa_next
+				ptr = interface.ifa_next
 			}
 			freeifaddrs(ifaddr)
 		}

--- a/Ksign/Backend/Server/ServerInstaller.swift
+++ b/Ksign/Backend/Server/ServerInstaller.swift
@@ -18,21 +18,42 @@ import IDeviceSwift
 class ServerInstaller: Identifiable, ObservableObject {
 	let id = UUID()
 	let port = Int.random(in: 4000...8000)
+	let requiresServer: Bool
 	private var _needsShutdown = false
 	
 	var packageUrl: URL?
-	var app: AppInfoPresentable
+	let appIdentifier: String?
+	let appName: String?
+	let appVersion: String?
 	@ObservedObject var viewModel: InstallerStatusViewModel
-	private let _server: Application
+	private var _server: Application?
+	private(set) var startupError: Error?
 
-	init(app: AppInfoPresentable, viewModel: InstallerStatusViewModel) throws {
-		self.app = app
+	init(app: AppInfoPresentable, viewModel: InstallerStatusViewModel, requiresServer: Bool = true) {
+		self.appIdentifier = app.identifier
+		self.appName = app.name
+		self.appVersion = app.version
 		self.viewModel = viewModel
-		self._server = try Self.setupApp(port: port)
-		
-		try _configureRoutes()
-		try _server.server.start()
-		_needsShutdown = true
+		self.requiresServer = requiresServer
+		self._server = nil
+		self.startupError = nil
+
+		guard requiresServer else { return }
+
+		do {
+			let server = try Self.setupApp(port: port)
+			self._server = server
+			try _configureRoutes()
+			try server.server.start()
+			_needsShutdown = true
+		} catch {
+			self._server?.shutdown()
+			self._server = nil
+			self.startupError = error
+			DispatchQueue.main.async {
+				viewModel.status = .broken(error)
+			}
+		}
 	}
 	
 	deinit {
@@ -40,7 +61,10 @@ class ServerInstaller: Identifiable, ObservableObject {
 	}
 		
 	private func _configureRoutes() throws {
-		_server.get("*") { [weak self] req in
+		guard let server = _server else {
+			throw ServerInstallerError.unavailable
+		}
+		server.get("*") { [weak self] req in
 			guard let self else { return Response(status: .badGateway) }
 			switch req.url.path {
 			case plistEndpoint.path:
@@ -84,11 +108,11 @@ class ServerInstaller: Identifiable, ObservableObject {
 	}
 	
 	private func _shutdownServer() {
-		guard _needsShutdown else { return }
+		guard _needsShutdown, let server = _server else { return }
 		
 		_needsShutdown = false
-		_server.server.shutdown()
-		_server.shutdown()
+		server.server.shutdown()
+		server.shutdown()
 	}
 	
     private func _updateStatus(_ newStatus: InstallerStatusViewModel.InstallerStatus) {
@@ -111,5 +135,19 @@ class ServerInstaller: Identifiable, ObservableObject {
 	
 	static func setIPFix(_ enabled: Bool) {
 		UserDefaults.standard.set(enabled, forKey: "Feather.ipFix")
+	}
+}
+
+enum ServerInstallerError: LocalizedError {
+	case unavailable
+	case missingTLSCredentials
+
+	var errorDescription: String? {
+		switch self {
+		case .unavailable:
+			return "Unable to start the local installation server."
+		case .missingTLSCredentials:
+			return "The local installation server is missing its TLS certificate or private key."
+		}
 	}
 }

--- a/Ksign/Backend/Storage/Storage+Certificate.swift
+++ b/Ksign/Backend/Storage/Storage+Certificate.swift
@@ -19,19 +19,30 @@ extension Storage {
 		expiration: Date,
 		completion: @escaping (Error?) -> Void
 	) {
-		let generator = UIImpactFeedbackGenerator(style: .light)
-		
-		let new = CertificatePair(context: context)
-		new.uuid = uuid
-		new.date = Date()
-		new.password = password
-		new.ppQCheck = ppq
-		new.expiration = expiration
-		new.nickname = nickname
-		
-        saveContext()
-        generator.impactOccurred()
-        completion(nil)
+		context.perform {
+			if let password, !CertificatePasswordStore.setPassword(password, for: uuid) {
+				completion(CertificateStorageError.passwordStoreFailed)
+				return
+			}
+
+			let new = CertificatePair(context: self.context)
+			new.uuid = uuid
+			new.date = Date()
+			new.password = nil
+			new.ppQCheck = ppq
+			new.expiration = expiration
+			new.nickname = nickname
+
+			do {
+				try self.context.save()
+				UIImpactFeedbackGenerator(style: .light).impactOccurred()
+				completion(nil)
+			} catch {
+				CertificatePasswordStore.deletePassword(for: uuid)
+				self.context.delete(new)
+				completion(error)
+			}
+		}
 	}
     
     func revokagedCertificate(for cert: CertificatePair) {
@@ -40,7 +51,7 @@ extension Storage {
         Zsign.checkRevokage(
             provisionPath: Storage.shared.getFile(.provision, from: cert)?.path ?? "",
             p12Path: Storage.shared.getFile(.certificate, from: cert)?.path ?? "",
-            p12Password: cert.password ?? ""
+            p12Password: password(for: cert)
         ) { (status, _, _) in
             if status == 1 {
                 DispatchQueue.main.async {
@@ -62,6 +73,9 @@ extension Storage {
     
 	func deleteCertificate(for cert: CertificatePair) {
 		do {
+			if let uuid = cert.uuid {
+				CertificatePasswordStore.deletePassword(for: uuid)
+			}
 			if cert.p12Data == nil && cert.provisionData == nil {
 				if let url = getUuidDirectory(for: cert) {
 					try FileManager.default.removeItem(at: url)
@@ -72,6 +86,33 @@ extension Storage {
 		} catch {
 			print(error)
 		}
+	}
+
+	func password(for cert: CertificatePair) -> String {
+		var uuid: String?
+		var legacyPassword: String?
+		context.performAndWait {
+			uuid = cert.uuid
+			legacyPassword = cert.password
+		}
+
+		guard let uuid else { return legacyPassword ?? "" }
+		if let password = CertificatePasswordStore.password(for: uuid) {
+			return password
+		}
+
+		guard let legacyPassword else { return "" }
+		if CertificatePasswordStore.setPassword(legacyPassword, for: uuid) {
+			context.perform {
+				cert.password = nil
+				do {
+					try self.context.save()
+				} catch {
+					print("Unable to remove legacy certificate password: \(error.localizedDescription)")
+				}
+			}
+		}
+		return legacyPassword
 	}
 		
 	enum FileRequest: String {
@@ -88,10 +129,20 @@ extension Storage {
 	}
 	
 	func getUuidDirectory(for cert: CertificatePair) -> URL? {
-		guard let uuid = cert.uuid else {
-			return nil
+		var uuid: String?
+		context.performAndWait {
+			uuid = cert.uuid
 		}
-		
+
+		guard let uuid else { return nil }
 		return FileManager.default.certificates(uuid)
+	}
+}
+
+private enum CertificateStorageError: LocalizedError {
+	case passwordStoreFailed
+
+	var errorDescription: String? {
+		"Unable to securely store the certificate password."
 	}
 }

--- a/Ksign/Backend/Storage/Storage+Imported.swift
+++ b/Ksign/Backend/Storage/Storage+Imported.swift
@@ -21,22 +21,26 @@ extension Storage {
 		
 		completion: @escaping (Error?) -> Void
 	) {
-		let generator = UIImpactFeedbackGenerator(style: .light)
-		
-		let new = Imported(context: context)
-		
-		new.uuid = uuid
-		new.source = source
-		new.date = Date()
-		// could possibly be nil, but thats fine.
-		// ?
-		new.identifier = appIdentifier
-		new.name = appName
-		new.icon = appIcon
-		new.version = appVersion
-		
-        saveContext()
-        generator.impactOccurred()
-        completion(nil)
+		context.perform {
+			let new = Imported(context: self.context)
+
+			new.uuid = uuid
+			new.source = source
+			new.date = Date()
+			new.identifier = appIdentifier
+			new.name = appName
+			new.icon = appIcon
+			new.version = appVersion
+
+			do {
+				try self.context.save()
+				SourceIntelligenceManager.shared.invalidateLocalVersionSnapshot()
+				UIImpactFeedbackGenerator(style: .light).impactOccurred()
+				completion(nil)
+			} catch {
+				self.context.delete(new)
+				completion(error)
+			}
+		}
 	}
 }

--- a/Ksign/Backend/Storage/Storage+Shared.swift
+++ b/Ksign/Backend/Storage/Storage+Shared.swift
@@ -10,8 +10,17 @@ import CoreData
 // MARK: - Class extension: Apps (Shared)
 extension Storage {
 	func getUuidDirectory(for app: AppInfoPresentable) -> URL? {
-		guard let uuid = app.uuid else { return nil }
-		return app.isSigned
+		var uuid: String?
+		if let object = app as? NSManagedObject, let managedObjectContext = object.managedObjectContext {
+			managedObjectContext.performAndWait {
+				uuid = app.uuid
+			}
+		} else {
+			uuid = app.uuid
+		}
+
+		guard let uuid else { return nil }
+		return app is Signed
 		? FileManager.default.signed(uuid)
 		: FileManager.default.unsigned(uuid)
 	}
@@ -22,22 +31,31 @@ extension Storage {
 	}
 	
 	func deleteApp(for app: AppInfoPresentable) {
-		do {
-			if let url = getUuidDirectory(for: app) {
-				try? FileManager.default.removeItem(at: url)
+		if let url = getUuidDirectory(for: app) {
+			try? FileManager.default.removeItem(at: url)
+		}
+		if let object = app as? NSManagedObject {
+			context.perform {
+				self.context.delete(object)
+				do {
+					try self.context.save()
+					SourceIntelligenceManager.shared.invalidateLocalVersionSnapshot()
+				} catch {
+					print("Unable to delete app: \(error.localizedDescription)")
+				}
 			}
-			if let object = app as? NSManagedObject {
-				context.delete(object)
-			}
-			saveContext()
 		}
 	}
 	
 	func getCertificate(from app: AppInfoPresentable) -> CertificatePair? {
-		if let signed = app as? Signed {
-			return signed.certificate
+		guard let signed = app as? Signed, let managedObjectContext = signed.managedObjectContext else {
+			return nil
 		}
-		return nil
+		var certificate: CertificatePair?
+		managedObjectContext.performAndWait {
+			certificate = signed.certificate
+		}
+		return certificate
 	}
 }
 

--- a/Ksign/Backend/Storage/Storage+Signed.swift
+++ b/Ksign/Backend/Storage/Storage+Signed.swift
@@ -22,23 +22,28 @@ extension Storage {
 		
 		completion: @escaping (Error?) -> Void
 	) {
-		let generator = UIImpactFeedbackGenerator(style: .light)
-		
-		let new = Signed(context: context)
-		
-		new.uuid = uuid
-		new.source = source
-		new.date = Date()
-		// if nil, we assume adhoc or certificate was deleted afterwards
-		new.certificate = certificate
-		// could possibly be nil, but thats fine.
-		new.identifier = appIdentifier
-		new.name = appName
-		new.icon = appIcon
-		new.version = appVersion
-		
-        saveContext()
-        generator.impactOccurred()
-        completion(nil)
+		context.perform {
+			let new = Signed(context: self.context)
+
+			new.uuid = uuid
+			new.source = source
+			new.date = Date()
+			// If nil, the app is ad-hoc signed or its certificate was deleted.
+			new.certificate = certificate
+			new.identifier = appIdentifier
+			new.name = appName
+			new.icon = appIcon
+			new.version = appVersion
+
+			do {
+				try self.context.save()
+				SourceIntelligenceManager.shared.invalidateLocalVersionSnapshot()
+				UIImpactFeedbackGenerator(style: .light).impactOccurred()
+				completion(nil)
+			} catch {
+				self.context.delete(new)
+				completion(error)
+			}
+		}
 	}
 }

--- a/Ksign/Backend/Storage/Storage+Sources.swift
+++ b/Ksign/Backend/Storage/Storage+Sources.swift
@@ -13,7 +13,11 @@ extension Storage {
 	/// Retrieve sources in an array, we don't normally need this in swiftUI but we have it for the copy sources action
 	func getSources() -> [AltSource] {
 		let request: NSFetchRequest<AltSource> = AltSource.fetchRequest()
-		return (try? context.fetch(request)) ?? []
+		var sources: [AltSource] = []
+		context.performAndWait {
+			sources = (try? context.fetch(request)) ?? []
+		}
+		return sources
 	}
 	
 	func addSource(
@@ -25,27 +29,23 @@ extension Storage {
 		isBuiltIn: Bool = false,
 		completion: @escaping (Error?) -> Void
 	) {
-		if sourceExists(identifier) {
-			completion(nil)
-			print("ignoring \(identifier)")
-			return
-		}
-		
-		let new = AltSource(context: context)
-		new.name = name
-		new.date = Date()
-		new.identifier = identifier
-		new.sourceURL = url
-		new.iconURL = iconURL
-		new.setValue(isBuiltIn, forKey: "isBuiltIn")
-		
-		do {
-			if !deferSave {
-				try context.save()
+		context.perform {
+			do {
+				try self._insertSource(
+					url,
+					name: name,
+					identifier: identifier,
+					iconURL: iconURL,
+					isBuiltIn: isBuiltIn
+				)
+				if !deferSave {
+					try self.context.save()
+				}
+				completion(nil)
+			} catch {
+				self.context.rollback()
+				completion(error)
 			}
-			completion(nil)
-		} catch {
-			completion(error)
 		}
 	}
 	
@@ -74,26 +74,66 @@ extension Storage {
 		repos: [URL: ASRepository],
 		completion: @escaping (Error?) -> Void
 	) {
-		for (url, repo) in repos {
-			addSource(
-				url,
-				repository: repo,
-				deferSave: true,
-				completion: { error in
-					if let error {
-						completion(error)
-					}
+		context.perform {
+			do {
+				for (url, repo) in repos {
+					try self._insertSource(
+						url,
+						name: repo.name,
+						identifier: repo.id ?? url.absoluteString,
+						iconURL: repo.currentIconURL,
+						isBuiltIn: false
+					)
 				}
-			)
+				try self.context.save()
+				completion(nil)
+			} catch {
+				self.context.rollback()
+				completion(error)
+			}
 		}
-		
-        saveContext()
-        completion(nil)
 	}
 
 
-	func addBuiltInSources() {
-		let builtInSourceURLs = [
+	func addBuiltInSources(completion: @escaping (Bool) -> Void) {
+		let group = DispatchGroup()
+		for urlString in _builtInSourceURLs {
+			group.enter()
+			FR.handleSource(urlString, isBuiltIn: true) { _ in
+				group.leave()
+			}
+		}
+
+		group.notify(queue: .main) {
+			let existingURLs = Set(self.getSources().compactMap { $0.sourceURL?.absoluteString })
+			completion(self._builtInSourceURLs.allSatisfy(existingURLs.contains))
+		}
+	}
+
+	func markBuiltInSources() {
+		let builtInURLs = Set(_builtInSourceURLs)
+		context.perform {
+			let request: NSFetchRequest<AltSource> = AltSource.fetchRequest()
+			do {
+				let sources = try self.context.fetch(request)
+				var didChange = false
+				for source in sources where builtInURLs.contains(source.sourceURL?.absoluteString ?? "") {
+					if !source.isBuiltIn {
+						source.isBuiltIn = true
+						didChange = true
+					}
+				}
+				if didChange {
+					try self.context.save()
+				}
+			} catch {
+				print("Unable to mark built-in sources: \(error.localizedDescription)")
+			}
+		}
+	}
+
+	private var _builtInSourceURLs: [String] {
+		[
             "https://raw.githubusercontent.com/Nyasami/Ksign/refs/heads/main/repo.json",
             "https://community-apps.sidestore.io/sidecommunity.json",
             "https://xitrix.github.io/iTorrent/AltStore.json",
@@ -102,18 +142,30 @@ extension Storage {
 			"https://ipa.cypwn.xyz/cypwn.json",
             "https://alt.crystall1ne.dev"
 		]
-		
-		for urlString in builtInSourceURLs {
-			FR.handleSource(urlString) { }
-		}
 	}
 
 	func deleteSource(for source: AltSource) {
-		context.delete(source)
-		saveContext()
+		SourceIntelligenceManager.shared.remove(source)
+		context.perform {
+			self.context.delete(source)
+			do {
+				try self.context.save()
+			} catch {
+				self.context.rollback()
+				print("Unable to delete source: \(error.localizedDescription)")
+			}
+		}
 	}
 
 	func sourceExists(_ identifier: String) -> Bool {
+		var exists = false
+		context.performAndWait {
+			exists = self._sourceExists(identifier)
+		}
+		return exists
+	}
+
+	private func _sourceExists(_ identifier: String) -> Bool {
 		let fetchRequest: NSFetchRequest<AltSource> = AltSource.fetchRequest()
 		fetchRequest.predicate = NSPredicate(format: "identifier == %@", identifier)
 
@@ -124,5 +176,26 @@ extension Storage {
 			print("Error checking if repository exists: \(error)")
 			return false
 		}
+	}
+
+	private func _insertSource(
+		_ url: URL,
+		name: String?,
+		identifier: String,
+		iconURL: URL?,
+		isBuiltIn: Bool
+	) throws {
+		guard !_sourceExists(identifier) else {
+			print("ignoring \(identifier)")
+			return
+		}
+
+		let new = AltSource(context: context)
+		new.name = name
+		new.date = Date()
+		new.identifier = identifier
+		new.sourceURL = url
+		new.iconURL = iconURL
+		new.setValue(isBuiltIn, forKey: "isBuiltIn")
 	}
 }

--- a/Ksign/Backend/Storage/Storage.swift
+++ b/Ksign/Backend/Storage/Storage.swift
@@ -5,12 +5,14 @@
 //  Created by samara on 10.04.2025.
 //
 
+import Combine
 import CoreData
 
 // MARK: - Class
 final class Storage: ObservableObject {
 	static let shared = Storage()
 	let container: NSPersistentContainer
+	@Published private(set) var persistentStoreError: Error?
 	
 	private let _name: String = "Feather"
 	
@@ -18,12 +20,15 @@ final class Storage: ObservableObject {
 		container = NSPersistentContainer(name: _name)
 		
 		if inMemory {
-			container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
+			container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
 		}
 		
 		container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-			if let error = error as NSError? {
-				fatalError("Unresolved error \(error), \(error.userInfo)")
+			if let error {
+				DispatchQueue.main.async {
+					self.persistentStoreError = error
+				}
+				print("Unable to load persistent store: \(error.localizedDescription)")
 			}
 		})
 		
@@ -33,26 +38,43 @@ final class Storage: ObservableObject {
 	var context: NSManagedObjectContext {
 		container.viewContext
 	}
+
+	func dismissPersistentStoreError() {
+		persistentStoreError = nil
+	}
 	
 	func saveContext() {
-        DispatchQueue.main.async {
-            if self.context.hasChanges {
-                try? self.context.save()
-            }
-        }
+		context.perform {
+			guard self.context.hasChanges else { return }
+			do {
+				try self.context.save()
+			} catch {
+				print("Unable to save persistent context: \(error.localizedDescription)")
+			}
+		}
 	}
 	
 	func clearContext<T: NSManagedObject>(request: NSFetchRequest<T>) {
-		let deleteRequest = NSBatchDeleteRequest(fetchRequest: (request as? NSFetchRequest<NSFetchRequestResult>)!)
-		do {
-			_ = try context.execute(deleteRequest)
-		} catch {
-			print("clear: \(error.localizedDescription)")
+		guard let untypedRequest = request as? NSFetchRequest<NSFetchRequestResult> else {
+			return
+		}
+		context.performAndWait {
+			let deleteRequest = NSBatchDeleteRequest(fetchRequest: untypedRequest)
+			do {
+				_ = try context.execute(deleteRequest)
+				context.reset()
+			} catch {
+				print("clear: \(error.localizedDescription)")
+			}
 		}
 	}
     
     func countContent<T: NSManagedObject>(for type: T.Type) -> String {
         let request = T.fetchRequest()
-        return "\((try? context.count(for: request)) ?? 0)"
+		var count = 0
+		context.performAndWait {
+			count = (try? context.count(for: request)) ?? 0
+		}
+		return "\(count)"
     }
 }

--- a/Ksign/Extensions/Logger++.swift
+++ b/Ksign/Extensions/Logger++.swift
@@ -8,7 +8,7 @@
 import OSLog
 
 extension Logger {
-	private static var subsystem = Bundle.main.bundleIdentifier!
+	private static var subsystem = Bundle.main.bundleIdentifier ?? "Ksign"
 	static let signing = Logger(subsystem: subsystem, category: "Signing")
 	static let misc = Logger(subsystem: subsystem, category: "Misc")
 }

--- a/Ksign/Extensions/UTType/UTType+cert.swift
+++ b/Ksign/Extensions/UTType/UTType+cert.swift
@@ -9,10 +9,10 @@ import UniformTypeIdentifiers
 
 extension UTType {
 	static var p12: UTType {
-		UTType(filenameExtension: "p12", conformingTo: .data)!
+		UTType(filenameExtension: "p12", conformingTo: .data) ?? .data
 	}
 	
 	static var mobileProvision: UTType {
-		UTType(filenameExtension: "mobileprovision", conformingTo: .data)!
+		UTType(filenameExtension: "mobileprovision", conformingTo: .data) ?? .data
 	}
 }

--- a/Ksign/Extensions/UTType/UTType+ipa.swift
+++ b/Ksign/Extensions/UTType/UTType+ipa.swift
@@ -9,11 +9,11 @@ import UniformTypeIdentifiers
 
 extension UTType {
 	static var ipa: UTType {
-		UTType(filenameExtension: "ipa")!
+		UTType(filenameExtension: "ipa") ?? .data
 	}
 	
 	static var tipa: UTType {
-		UTType(filenameExtension: "tipa")!
+		UTType(filenameExtension: "tipa") ?? .data
 	}
 }
 

--- a/Ksign/Extensions/UTType/UTType+plist.swift
+++ b/Ksign/Extensions/UTType/UTType+plist.swift
@@ -10,14 +10,14 @@ import UniformTypeIdentifiers
 
 extension UTType {
 	static var plist: UTType {
-		UTType(filenameExtension: "plist", conformingTo: .data)!
+		UTType(filenameExtension: "plist", conformingTo: .data) ?? .data
 	}
 	
 	static var mobiledevicepairing: UTType {
-		UTType(filenameExtension: "mobiledevicepairing", conformingTo: .data)!
+		UTType(filenameExtension: "mobiledevicepairing", conformingTo: .data) ?? .data
 	}
 	
 	static var entitlements: UTType {
-		UTType(filenameExtension: "entitlements", conformingTo: .data)!
+		UTType(filenameExtension: "entitlements", conformingTo: .data) ?? .data
 	}
 }

--- a/Ksign/Extensions/UTType/UTType+tweak.swift
+++ b/Ksign/Extensions/UTType/UTType+tweak.swift
@@ -9,16 +9,16 @@ import UniformTypeIdentifiers
 
 extension UTType {
 	static var dylib: UTType {
-		UTType(filenameExtension: "dylib")!
+		UTType(filenameExtension: "dylib") ?? .data
 	}
     static var bundle: UTType {
-        UTType(filenameExtension: "bundle")!
+        UTType(filenameExtension: "bundle") ?? .folder
     }
 	static var deb: UTType {
-		UTType(filenameExtension: "deb")!
+		UTType(filenameExtension: "deb") ?? .data
 	}
 	
 	static var framework: UTType {
-		UTType(filenameExtension: "framework")!
+		UTType(filenameExtension: "framework") ?? .folder
 	}
 }

--- a/Ksign/FeatherApp.swift
+++ b/Ksign/FeatherApp.swift
@@ -18,7 +18,7 @@ struct FeatherApp: App {
 	@StateObject var accentColorManager = AccentColorManager.shared
     @StateObject var extractManager = ExtractManager.shared
 	@StateObject var logsManager = LogsManager.shared
-	let storage = Storage.shared
+	@StateObject private var storage = Storage.shared
 
 	var body: some Scene {
 		WindowGroup {
@@ -41,13 +41,30 @@ struct FeatherApp: App {
 				accentColorManager.updateGlobalTintColor()
 				if logsManager.isCapturing { logsManager.startCapture() }
 			}
+			.alert(
+				.localized("Storage Error"),
+				isPresented: Binding(
+					get: { storage.persistentStoreError != nil },
+					set: { isPresented in
+						if !isPresented {
+							storage.dismissPersistentStoreError()
+						}
+					}
+				)
+			) {
+				Button(.localized("OK")) {
+					storage.dismissPersistentStoreError()
+				}
+			} message: {
+				Text(storage.persistentStoreError?.localizedDescription ?? .localized("Unable to load app data."))
+			}
 		}
 	}
 	
 	private func _handleURL(_ url: URL) {
 		if url.scheme == "ksign" {
 			if let fullPath = url.validatedScheme(after: "/source/") {
-				FR.handleSource(fullPath) { }
+				FR.handleSource(fullPath) { _ in }
 			}
 			
 			if
@@ -86,8 +103,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         _createSourcesDirectory()
         if !UserDefaults.standard.bool(forKey: "hasInitializedBuiltInSources") {
             _initializeBuiltInSources()
-            UserDefaults.standard.set(true, forKey: "hasInitializedBuiltInSources")
         }
+        Storage.shared.markBuiltInSources()
         
         _clean()
         
@@ -102,7 +119,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     }
     
     private func _initializeBuiltInSources() { 
-        Storage.shared.addBuiltInSources()
+        Storage.shared.addBuiltInSources { success in
+			if success {
+				UserDefaults.standard.set(true, forKey: "hasInitializedBuiltInSources")
+			}
+		}
     }
     
     private func _createPipeline() {
@@ -163,7 +184,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         let filesToCopy = ["server.crt", "server.pem", "commonName.txt"]
         
         for fileName in filesToCopy {
-            guard let bundleURL = Bundle.main.url(forResource: fileName.components(separatedBy: ".").first!, withExtension: fileName.components(separatedBy: ".").last!) else {
+			let fileURL = URL(fileURLWithPath: fileName)
+            guard let bundleURL = Bundle.main.url(
+				forResource: fileURL.deletingPathExtension().lastPathComponent,
+				withExtension: fileURL.pathExtension
+			) else {
                 print("File \(fileName) not found in app bundle")
                 continue
             }

--- a/Ksign/Utilities/ARDecompression/AR.swift
+++ b/Ksign/Utilities/ARDecompression/AR.swift
@@ -10,13 +10,14 @@ import Foundation
 class AR: NSObject {
 	private var _data: Data
 	
-	init(with url: URL) {
-		self._data = try! Data(contentsOf: url)
+	init(with url: URL) throws {
+		self._data = try Data(contentsOf: url, options: .mappedIfSafe)
 		super.init()
 	}
 	
 	func extract() async throws -> [ARFileModel] {
-		if [UInt8](_data.subdata(in: Range(0...7))) != [0x21, 0x3c, 0x61, 0x72, 0x63, 0x68, 0x3e, 0x0a] {
+		let magic: [UInt8] = [0x21, 0x3c, 0x61, 0x72, 0x63, 0x68, 0x3e, 0x0a]
+		guard _data.count >= magic.count, Array(_data.prefix(magic.count)) == magic else {
 			throw ARError.badArchive("Invalid magic")
 		}
 		
@@ -25,6 +26,9 @@ class AR: NSObject {
 		var offset = 0
 		var files: [ARFileModel] = []
 		while offset < data.count {
+			guard data.count - offset >= 60 else {
+				throw ARError.badArchive("Truncated file header")
+			}
 			let fileInfo = try _getFileInfo(data, offset)
 			files.append(fileInfo)
 			offset += fileInfo.size + 60
@@ -34,39 +38,61 @@ class AR: NSObject {
 	}
 	
 	private func _getFileInfo(_ data: Data, _ offset: Int) throws -> ARFileModel {
-		let size = Int(_removePadding(String(data: data.subdata(in: offset+48..<offset+48+10), encoding: .ascii) ?? "0"))!
-		if size < 1 {
+		guard
+			offset >= 0,
+			data.count - offset >= 60,
+			let size = Int(_field(data, offset: offset + 48, length: 10)),
+			size >= 0,
+			size <= data.count - offset - 60
+		else {
 			throw ARError.badArchive("Invalid size")
 		}
+
+		guard data[offset + 58] == 0x60, data[offset + 59] == 0x0A else {
+			throw ARError.badArchive("Invalid file header")
+		}
 		
-		let name = _removePadding(String(data: data.subdata(in: offset..<offset+16), encoding: .ascii) ?? "")
-		guard name != "" else {
+		var name = _field(data, offset: offset, length: 16)
+		if name.hasSuffix("/") {
+			name.removeLast()
+		}
+		guard !name.isEmpty else {
 			throw ARError.badArchive("Invalid name")
+		}
+
+		guard
+			let ownerID = Int(_field(data, offset: offset + 28, length: 6)),
+			let groupID = Int(_field(data, offset: offset + 34, length: 6)),
+			let mode = Int(_field(data, offset: offset + 40, length: 8))
+		else {
+			throw ARError.badArchive("Invalid file metadata")
 		}
 		
 		return ARFileModel(
 			name: name,
-			modificationDate: NSDate(timeIntervalSince1970: Double(_removePadding(String(data: data.subdata(in: offset+16..<offset+16+12), encoding: .ascii) ?? "0"))!) as Date,
-			ownerId: Int(_removePadding(String(data: data.subdata(in: offset+28..<offset+28+6), encoding: .ascii) ?? "0"))!,
-			groupId: Int(_removePadding(String(data: data.subdata(in: offset+34..<offset+34+6), encoding: .ascii) ?? "0"))!,
-			mode: Int(_removePadding(String(data: data.subdata(in: offset+40..<offset+40+8), encoding: .ascii) ?? "0"))!,
+			modificationDate: Date(timeIntervalSince1970: Double(_field(data, offset: offset + 16, length: 12)) ?? 0),
+			ownerId: ownerID,
+			groupId: groupID,
+			mode: mode,
 			size: size,
 			content: data.subdata(in: offset+60..<offset+60+size)
 		)
 	}
 	
-	private func _removePadding(_ paddedString: String) -> String {
-		let data = paddedString.data(using: .utf8)!
-		
-		guard let firstNonSpaceIndex = data.firstIndex(of: UInt8(ascii: " ")) else {
-			return paddedString
-		}
-		
-		let actualData = data[..<firstNonSpaceIndex]
-		return String(data: actualData, encoding: .utf8)!
+	private func _field(_ data: Data, offset: Int, length: Int) -> String {
+		guard offset >= 0, length >= 0, offset + length <= data.count else { return "" }
+		return String(data: data.subdata(in: offset..<offset+length), encoding: .ascii)?
+			.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 	}
 }
 
-enum ARError: Error {
+enum ARError: LocalizedError {
 	case badArchive(String)
+
+	var errorDescription: String? {
+		switch self {
+		case .badArchive(let message):
+			return "Invalid AR archive: \(message)"
+		}
+	}
 }

--- a/Ksign/Utilities/ARDecompression/Decompression.swift
+++ b/Ksign/Utilities/ARDecompression/Decompression.swift
@@ -29,18 +29,22 @@ func extractFile(at fileURL: inout URL) throws {
 	}
 	
 	if fileExtension == "tar" {
-		let tarData = try Data(contentsOf: fileURL)
+		let tarData = try Data(contentsOf: fileURL, options: .mappedIfSafe)
 		let tarContainer = try TarContainer.open(container: tarData)
 		
 		let extractionDirectory = fileURL.deletingLastPathComponent().appendingPathComponent(UUID().uuidString)
 		try fileManager.createDirectory(at: extractionDirectory, withIntermediateDirectories: true)
 		
 		for entry in tarContainer {
-			let entryPath = extractionDirectory.appendingPathComponent(entry.info.name)
+			let entryPath = try ArchivePathValidator.destinationURL(
+				base: extractionDirectory,
+				entryPath: entry.info.name
+			)
 			
 			if entry.info.type == .directory {
 				try fileManager.createDirectory(at: entryPath, withIntermediateDirectories: true)
 			} else if entry.info.type == .regular, let entryData = entry.data {
+				try fileManager.createDirectoryIfNeeded(at: entryPath.deletingLastPathComponent())
 				try entryData.write(to: entryPath)
 			}
 		}

--- a/Ksign/Utilities/ArchivePathValidator.swift
+++ b/Ksign/Utilities/ArchivePathValidator.swift
@@ -1,0 +1,51 @@
+import Foundation
+import ZIPFoundation
+
+enum ArchivePathError: LocalizedError {
+	case unsafePath(String)
+	case unsupportedEntry(String)
+
+	var errorDescription: String? {
+		switch self {
+		case .unsafePath(let path):
+			return "Archive contains an unsafe path: \(path)"
+		case .unsupportedEntry(let path):
+			return "Archive contains an unsupported link entry: \(path)"
+		}
+	}
+}
+
+enum ArchivePathValidator {
+	static func destinationURL(base: URL, entryPath: String) throws -> URL {
+		let normalizedPath = entryPath.replacingOccurrences(of: "\\", with: "/")
+		guard
+			!normalizedPath.isEmpty,
+			!normalizedPath.hasPrefix("/"),
+			!normalizedPath.contains("\0")
+		else {
+			throw ArchivePathError.unsafePath(entryPath)
+		}
+
+		let resolvedBase = base.standardizedFileURL.resolvingSymlinksInPath()
+		let destination = base
+			.appendingPathComponent(normalizedPath)
+			.standardizedFileURL
+			.resolvingSymlinksInPath()
+		let basePath = resolvedBase.path.hasSuffix("/") ? resolvedBase.path : resolvedBase.path + "/"
+
+		guard destination.path == resolvedBase.path || destination.path.hasPrefix(basePath) else {
+			throw ArchivePathError.unsafePath(entryPath)
+		}
+		return destination
+	}
+
+	static func validateZipArchive(at archiveURL: URL, destination: URL) throws {
+		let archive = try Archive(url: archiveURL, accessMode: .read)
+		for entry in archive {
+			_ = try destinationURL(base: destination, entryPath: entry.path)
+			if entry.type == .symlink {
+				throw ArchivePathError.unsupportedEntry(entry.path)
+			}
+		}
+	}
+}

--- a/Ksign/Utilities/BackgroundTaskManager.swift
+++ b/Ksign/Utilities/BackgroundTaskManager.swift
@@ -13,7 +13,7 @@ import CryptoKit
 class BackgroundTaskManager: ObservableObject {
     static let shared = BackgroundTaskManager()
     
-    private let baseId = "\(Bundle.main.bundleIdentifier!).userTask"
+    private let baseId = "\(Bundle.main.bundleIdentifier ?? "Ksign").userTask"
     
     private var activeTasks: [String: BGContinuedProcessingTask] = [:]
     private var registeredTasks: Set<String> = []

--- a/Ksign/Utilities/CertificateReader/CertificatePasswordStore.swift
+++ b/Ksign/Utilities/CertificateReader/CertificatePasswordStore.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Security
+
+enum CertificatePasswordStore {
+	private static var service: String {
+		"\(Bundle.main.bundleIdentifier ?? "Ksign").certificate-password"
+	}
+
+	static func password(for uuid: String) -> String? {
+		let query: [String: Any] = [
+			kSecClass as String: kSecClassGenericPassword,
+			kSecAttrService as String: service,
+			kSecAttrAccount as String: uuid,
+			kSecReturnData as String: true,
+			kSecMatchLimit as String: kSecMatchLimitOne
+		]
+
+		var result: CFTypeRef?
+		guard
+			SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+			let data = result as? Data
+		else {
+			return nil
+		}
+		return String(data: data, encoding: .utf8)
+	}
+
+	@discardableResult
+	static func setPassword(_ password: String, for uuid: String) -> Bool {
+		guard let data = password.data(using: .utf8) else { return false }
+
+		let query = _baseQuery(for: uuid)
+		let attributes: [String: Any] = [
+			kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+			kSecValueData as String: data
+		]
+		let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+		guard updateStatus == errSecItemNotFound else {
+			if updateStatus != errSecSuccess {
+				print("Unable to update certificate password in Keychain: \(updateStatus)")
+			}
+			return updateStatus == errSecSuccess
+		}
+
+		let newItem: [String: Any] = [
+			kSecClass as String: kSecClassGenericPassword,
+			kSecAttrService as String: service,
+			kSecAttrAccount as String: uuid,
+			kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+			kSecValueData as String: data
+		]
+		let addStatus = SecItemAdd(newItem as CFDictionary, nil)
+		if addStatus != errSecSuccess {
+			print("Unable to add certificate password to Keychain: \(addStatus)")
+		}
+		return addStatus == errSecSuccess
+	}
+
+	static func deletePassword(for uuid: String) {
+		let status = SecItemDelete(_baseQuery(for: uuid) as CFDictionary)
+		if status != errSecSuccess, status != errSecItemNotFound {
+			print("Unable to delete certificate password from Keychain: \(status)")
+		}
+	}
+
+	private static func _baseQuery(for uuid: String) -> [String: Any] {
+		[
+			kSecClass as String: kSecClassGenericPassword,
+			kSecAttrService as String: service,
+			kSecAttrAccount as String: uuid
+		]
+	}
+}

--- a/Ksign/Utilities/CertificateReader/CertificateSelection.swift
+++ b/Ksign/Utilities/CertificateReader/CertificateSelection.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum CertificateSelection {
+	static let uuidKey = "feather.selectedCertUUID"
+	private static let legacyIndexKey = "feather.selectedCert"
+
+	static func selected(in certificates: [CertificatePair], uuid: String) -> CertificatePair? {
+		if let selected = certificates.first(where: { $0.uuid == uuid }) {
+			return selected
+		}
+
+		let legacyIndex = UserDefaults.standard.integer(forKey: legacyIndexKey)
+		if certificates.indices.contains(legacyIndex) {
+			let selected = certificates[legacyIndex]
+			UserDefaults.standard.set(selected.uuid, forKey: uuidKey)
+			UserDefaults.standard.removeObject(forKey: legacyIndexKey)
+			return selected
+		}
+
+		guard let first = certificates.first else { return nil }
+		UserDefaults.standard.set(first.uuid, forKey: uuidKey)
+		return first
+	}
+
+	static func clear() {
+		UserDefaults.standard.removeObject(forKey: uuidKey)
+		UserDefaults.standard.removeObject(forKey: legacyIndexKey)
+	}
+}

--- a/Ksign/Utilities/FR.swift
+++ b/Ksign/Utilities/FR.swift
@@ -18,21 +18,35 @@ enum FR {
 		download: Download? = nil,
 		completion: @escaping (Error?) -> Void
 	) {
+		let jobID = download?.jobID ?? JobsManager.shared.start(
+			kind: .importApp,
+			title: ipa.lastPathComponent,
+			detail: .localized("Preparing import"),
+			sourceURL: ipa
+		)
 		Task.detached {
 			let handler = AppFileHandler(file: ipa, download: download)
 			
 			do {
 				try await handler.copy()
+				JobsManager.shared.update(jobID, progress: 0.1, detail: .localized("Extracting"))
 				try await handler.extract()
+				JobsManager.shared.update(jobID, progress: 0.85, detail: .localized("Saving to Library"))
 				try await handler.move()
 				try await handler.addToDatabase()
                 
                                 try? await handler.clean()
+				if download == nil {
+					JobsManager.shared.complete(jobID, detail: .localized("Imported to Library"))
+				}
 				await MainActor.run {
 					completion(nil)
 				}
 			} catch {
 				try await handler.clean()
+				if download == nil {
+					JobsManager.shared.fail(jobID, error: error, detail: .localized("Import failed"))
+				}
 				await MainActor.run {
 					completion(error)
 				}
@@ -48,26 +62,54 @@ enum FR {
 		completion: @escaping (Error?) -> Void
 	) {
 		Task.detached {
-			let handler = SigningHandler(app: app, options: options)
-			if !options.onlyModify {
-				handler.appCertificate = certificate
-			}
-			handler.appIcon = icon
-			
 			do {
-				try await handler.copy()
-				try await handler.modify()
-                try? await handler.clean()
-				
+				try await signPackageFile(
+					app,
+					using: options,
+					icon: icon,
+					certificate: certificate
+				)
 				await MainActor.run {
 					completion(nil)
 				}
 			} catch {
-				try? await handler.clean()
 				await MainActor.run {
 					completion(error)
 				}
 			}
+		}
+	}
+
+	static func signPackageFile(
+		_ app: AppInfoPresentable,
+		using options: Options,
+		icon: UIImage?,
+		certificate: CertificatePair?
+	) async throws {
+		let appName = await MainActor.run {
+			app.name ?? String.localized("Unknown App")
+		}
+		let jobID = JobsManager.shared.start(
+			kind: .signing,
+			title: appName,
+			detail: .localized("Preparing")
+		)
+		let handler = SigningHandler(app: app, options: options)
+		if !options.onlyModify {
+			handler.appCertificate = certificate
+		}
+		handler.appIcon = icon
+
+		do {
+			try await handler.copy()
+			JobsManager.shared.update(jobID, progress: 0.15, detail: .localized("Modifying and signing"))
+			try await handler.modify()
+			try? await handler.clean()
+			JobsManager.shared.complete(jobID, detail: .localized("Signing completed"))
+		} catch {
+			try? await handler.clean()
+			JobsManager.shared.fail(jobID, error: error, detail: .localized("Signing failed"))
+			throw error
 		}
 	}
 	
@@ -78,6 +120,11 @@ enum FR {
 		certificateName: String,
 		completion: @escaping (Error?) -> Void
 	) {
+		let jobID = JobsManager.shared.start(
+			kind: .certificateImport,
+			title: certificateName.isEmpty ? p12URL.lastPathComponent : certificateName,
+			detail: .localized("Importing certificate")
+		)
 		Task.detached {
 			let handler = CertificateFileHandler(
 				key: p12URL,
@@ -88,11 +135,14 @@ enum FR {
 			
 			do {
 				try await handler.copy()
+				JobsManager.shared.update(jobID, progress: 0.7, detail: .localized("Saving certificate"))
 				try await handler.addToDatabase()
+				JobsManager.shared.complete(jobID, detail: .localized("Certificate imported"))
 				await MainActor.run {
 					completion(nil)
 				}
 			} catch {
+				JobsManager.shared.fail(jobID, error: error, detail: .localized("Certificate import failed"))
 				await MainActor.run {
 					completion(error)
 				}
@@ -191,9 +241,13 @@ enum FR {
 	
 	static func handleSource(
 		_ urlString: String,
-		competion: @escaping () -> Void
+		isBuiltIn: Bool = false,
+		completion: @escaping (Bool) -> Void
 	) {
-		guard let url = URL(string: urlString) else { return }
+		guard let url = URL(string: urlString) else {
+			completion(false)
+			return
+		}
 		
 		NBFetchService().fetch<ASRepository>(from: url) { (result: Result<ASRepository, Error>) in
 			switch result {
@@ -201,18 +255,24 @@ enum FR {
 				let id = data.id ?? url.absoluteString
 				
 				if !Storage.shared.sourceExists(id) {
-					Storage.shared.addSource(url, repository: data, id: id) { _ in
-						competion()
+					Storage.shared.addSource(url, repository: data, id: id, isBuiltIn: isBuiltIn) { error in
+						completion(error == nil)
 					}
 				} else {
-					DispatchQueue.main.async {
-						UIAlertController.showAlertWithOk(title: "Error", message: "Repository already added.")
+					if !isBuiltIn {
+						DispatchQueue.main.async {
+							UIAlertController.showAlertWithOk(title: "Error", message: "Repository already added.")
+						}
 					}
+					completion(isBuiltIn)
 				}
 			case .failure(let error):
-				DispatchQueue.main.async {
-					UIAlertController.showAlertWithOk(title: "Error", message: error.localizedDescription)
+				if !isBuiltIn {
+					DispatchQueue.main.async {
+						UIAlertController.showAlertWithOk(title: "Error", message: error.localizedDescription)
+					}
 				}
+				completion(false)
 			}
 		}
 	}

--- a/Ksign/Utilities/Handlers/AppFileHandler.swift
+++ b/Ksign/Utilities/Handlers/AppFileHandler.swift
@@ -75,6 +75,7 @@ final class AppFileHandler: NSObject, @unchecked Sendable {
 	}
 	
 	private func _Zip(download: Download?) throws {
+		try ArchivePathValidator.validateZipArchive(at: _ipa, destination: _uniqueWorkDir)
 		try Zip.unzipFile(
 			_ipa,
 			destination: _uniqueWorkDir,
@@ -84,6 +85,11 @@ final class AppFileHandler: NSObject, @unchecked Sendable {
 				if let download = download {
 					DispatchQueue.main.async {
 						download.unpackageProgress = progress
+						JobsManager.shared.update(
+							download.jobID,
+							progress: download.overallProgress,
+							detail: .localized("Importing")
+						)
                         if #available(iOS 26.0, *) {
                             BackgroundTaskManager.shared.updateProgress(for: download.id, progress: download.overallProgress)
                         }
@@ -103,19 +109,29 @@ final class AppFileHandler: NSObject, @unchecked Sendable {
 			if let download = download {
 				DispatchQueue.main.async {
 					download.unpackageProgress = progress
+					JobsManager.shared.update(
+						download.jobID,
+						progress: download.overallProgress,
+						detail: .localized("Importing")
+					)
                     if #available(iOS 26.0, *) {
                         BackgroundTaskManager.shared.updateProgress(for: download.id, progress: download.overallProgress)
                     }
 				}
 			}
-			let destinationPath = _uniqueWorkDir.appendingPathComponent(entry.path)
+			let destinationPath = try ArchivePathValidator.destinationURL(
+				base: _uniqueWorkDir,
+				entryPath: entry.path
+			)
 			switch entry.type {
 			case .directory:
 				try _fileManager.createDirectory(at: destinationPath, withIntermediateDirectories: true)
-			default:
+			case .file:
 				let parent = destinationPath.deletingLastPathComponent()
 				try _fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
 				try archive.extract(entry, to: destinationPath)
+			case .symlink:
+				throw ArchivePathError.unsupportedEntry(entry.path)
 			}
 		}
 	}
@@ -141,19 +157,32 @@ final class AppFileHandler: NSObject, @unchecked Sendable {
 		let app = try await _directory()
 		
 		guard let appUrl = _fileManager.getPath(in: app, for: "app") else {
-			return
+			try? _fileManager.removeItem(at: app)
+			throw ImportedFileHandlerError.payloadNotFound
 		}
 		
 		let bundle = Bundle(url: appUrl)
-		
-		Storage.shared.addImported(
-			uuid: _uuid,
-			appName: bundle?.name,
-			appIdentifier: bundle?.bundleIdentifier,
-			appVersion: bundle?.version,
-			appIcon: bundle?.iconFileName
-		) { _ in
-			print("[\(self._uuid)] Added to database")
+
+		do {
+			try await withCheckedThrowingContinuation { continuation in
+				Storage.shared.addImported(
+					uuid: _uuid,
+					appName: bundle?.name,
+					appIdentifier: bundle?.bundleIdentifier,
+					appVersion: bundle?.version,
+					appIcon: bundle?.iconFileName
+				) { error in
+					if let error {
+						continuation.resume(throwing: error)
+					} else {
+						print("[\(self._uuid)] Added to database")
+						continuation.resume()
+					}
+				}
+			}
+		} catch {
+			try? _fileManager.removeItem(at: app)
+			throw error
 		}
 	}
 	
@@ -167,7 +196,7 @@ final class AppFileHandler: NSObject, @unchecked Sendable {
 	}
 }
 
-enum ImportedFileHandlerError: Error, CustomStringConvertible {
+enum ImportedFileHandlerError: Error, CustomStringConvertible, LocalizedError {
 	case payloadNotFound
 	case notEnoughDiskSpace(needed: Int64, available: Int64)
 	case extractionFailed
@@ -186,5 +215,9 @@ enum ImportedFileHandlerError: Error, CustomStringConvertible {
 		case .zipLibraryNotAvailable:
 			return "Zip library is not available on this platform."
 		}
+	}
+
+	var errorDescription: String? {
+		description
 	}
 }

--- a/Ksign/Utilities/Handlers/ArchiveHandler.swift
+++ b/Ksign/Utilities/Handlers/ArchiveHandler.swift
@@ -52,12 +52,17 @@ final class ArchiveHandler: NSObject {
 			
 			let zipUrl = self._uniqueWorkDir.appendingPathComponent("Archive.zip")
 			let ipaUrl = self._uniqueWorkDir.appendingPathComponent("Archive.ipa")
+			let compressionLevels = ZipCompression.allCases
+			let compressionIndex = min(
+				max(ArchiveHandler.getCompressionLevel(), 0),
+				max(compressionLevels.count - 1, 0)
+			)
 			
 			try await Zip.zipFiles(
 				paths: [payloadUrl],
 				zipFilePath: zipUrl,
 				password: nil,
-				compression: ZipCompression.allCases[ArchiveHandler.getCompressionLevel()],
+				compression: compressionLevels[compressionIndex],
 				progress: { progress in
 					
 					Task { @MainActor in
@@ -71,17 +76,24 @@ final class ArchiveHandler: NSObject {
 	}
 	
 	func moveToArchive(_ package: URL, shouldOpen: Bool = false) async throws -> URL? {
-		let appendingString = "\(_app.name!)_\(_app.version!)_\(Int(Date().timeIntervalSince1970)).ipa"
+		try _fileManager.createDirectoryIfNeeded(at: _fileManager.archives)
+		let rawName = await MainActor.run {
+			"\(_app.name ?? "Unknown")_\(_app.version ?? "0")"
+		}
+		let safeName = rawName.components(separatedBy: CharacterSet(charactersIn: "/:?*<>|\"\\")).joined()
+		let appendingString = "\(safeName)_\(Int(Date().timeIntervalSince1970)).ipa"
 		let dest = _fileManager.archives.appendingPathComponent(appendingString)
 		
-		try? _fileManager.moveItem(
+		try _fileManager.moveItem(
 			at: package,
 			to: dest
 		)
 		
 		if shouldOpen {
 			await MainActor.run {
-				UIApplication.open(FileManager.default.archives.toSharedDocumentsURL()!)
+				if let url = FileManager.default.archives.toSharedDocumentsURL() {
+					UIApplication.open(url)
+				}
 			}
 		}
 		

--- a/Ksign/Utilities/Handlers/CertificateFileHandler.swift
+++ b/Ksign/Utilities/Handlers/CertificateFileHandler.swift
@@ -43,21 +43,39 @@ final class CertificateFileHandler: NSObject {
 		
 		let destinationURL = try await _directory()
 
-		try _fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true)
-		try _fileManager.copyItem(at: _key, to: destinationURL.appendingPathComponent(_key.lastPathComponent))
-		try _fileManager.copyItem(at: _provision, to: destinationURL.appendingPathComponent(_provision.lastPathComponent))
+		do {
+			try _fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true)
+			try _fileManager.copyItem(at: _key, to: destinationURL.appendingPathComponent(_key.lastPathComponent))
+			try _fileManager.copyItem(at: _provision, to: destinationURL.appendingPathComponent(_provision.lastPathComponent))
+		} catch {
+			try? _fileManager.removeItem(at: destinationURL)
+			throw error
+		}
 	}
 	
 	func addToDatabase() async throws {
-		
-		Storage.shared.addCertificate(
-			uuid: _uuid,
-			password: _keyPassword,
-			nickname: _certNickname,
-			ppq: _certPair?.PPQCheck ?? false,
-			expiration: _certPair?.ExpirationDate ?? Date()
-		) { _ in
-			print("[\(self._uuid)] Added to database")
+		do {
+			try await withCheckedThrowingContinuation { continuation in
+				Storage.shared.addCertificate(
+					uuid: _uuid,
+					password: _keyPassword,
+					nickname: _certNickname,
+					ppq: _certPair?.PPQCheck ?? false,
+					expiration: _certPair?.ExpirationDate ?? Date()
+				) { error in
+					if let error {
+						continuation.resume(throwing: error)
+					} else {
+						print("[\(self._uuid)] Added to database")
+						continuation.resume()
+					}
+				}
+			}
+		} catch {
+			if let directory = try? await _directory() {
+				try? _fileManager.removeItem(at: directory)
+			}
+			throw error
 		}
 	}
 	
@@ -67,6 +85,10 @@ final class CertificateFileHandler: NSObject {
 	}
 }
 
-private enum CertificateFileHandlerError: Error {
+private enum CertificateFileHandlerError: LocalizedError {
 	case certNotValid
+
+	var errorDescription: String? {
+		"The certificate provisioning profile is invalid."
+	}
 }

--- a/Ksign/Utilities/Handlers/SigningHandler.swift
+++ b/Ksign/Utilities/Handlers/SigningHandler.swift
@@ -60,9 +60,10 @@ final class SigningHandler: NSObject {
 		}
 		
 		guard
-			let infoDictionary = NSDictionary(
+			let dictionary = NSDictionary(
 				contentsOf: movedAppPath.appendingPathComponent("Info.plist")
-			)!.mutableCopy() as? NSMutableDictionary
+			),
+			let infoDictionary = dictionary.mutableCopy() as? NSMutableDictionary
 		else {
 			throw SigningFileHandlerError.infoPlistNotFound
 		}
@@ -86,20 +87,16 @@ final class SigningHandler: NSObject {
 		}
 		
         try await _removeCodeSignature(for: movedAppPath)
-		try await _removeProvisioning(for: movedAppPath)
-		
-        try await _inject(for: movedAppPath, with: _options.injectionFiles, with: _options)
+		if _options.removeProvisioning {
+			try await _removeProvisioning(for: movedAppPath)
+		}
         
         if _options.experiment_supportLiquidGlass {
             try await _locateMachosAndChangeToSDK26(for: movedAppPath)
         }
-        
-        if _options.experiment_replaceSubstrateWithEllekit {
+
+        if !_options.injectionFiles.isEmpty || _options.experiment_replaceSubstrateWithEllekit {
             try await _inject(for: movedAppPath, with: _options.injectionFiles, with: _options)
-        } else {
-            if !_options.injectionFiles.isEmpty {
-                try await _inject(for: movedAppPath, with: _options.injectionFiles, with: _options)
-            }
         }
         
         if #available(iOS 19, *) {
@@ -110,8 +107,6 @@ final class SigningHandler: NSObject {
         try await handler.disinject()
 		
 		if !_options.onlyModify {
-			let handler = ZsignHandler(appUrl: movedAppPath, options: _options, cert: appCertificate)
-			
 			if _options.doAdhocSigning {
 				try await handler.adhocSign()
 			} else if (appCertificate != nil) {
@@ -119,13 +114,13 @@ final class SigningHandler: NSObject {
 			} else {
 				throw SigningFileHandlerError.missingCertifcate
 			}
+
+			if let error = handler.hadError {
+				throw error
+			}
 		}
         try await self.move()
         try await self.addToDatabase()
-
-        if let error = handler.hadError {
-            throw error
-        }
 	}
 	
 	func move() async throws {
@@ -148,23 +143,33 @@ final class SigningHandler: NSObject {
 		let app = try await _directory()
 		
 		guard let appUrl = _fileManager.getPath(in: app, for: "app") else {
-			return
+			try? _fileManager.removeItem(at: app)
+			throw SigningFileHandlerError.appNotFound
 		}
 		
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            let bundle = Bundle(url: appUrl)
+		let bundle = Bundle(url: appUrl)
 
-            Storage.shared.addSigned(
-                uuid: _uuid,
-                certificate: _options.doAdhocSigning ? nil : appCertificate,
-                appName: bundle?.name,
-                appIdentifier: bundle?.bundleIdentifier,
-                appVersion: bundle?.version,
-                appIcon: bundle?.iconFileName
-            ) { _ in
-                Logger.signing.info("[\(self._uuid)] Added to database")
-                continuation.resume()
-            }
+		do {
+			try await withCheckedThrowingContinuation { continuation in
+				Storage.shared.addSigned(
+					uuid: _uuid,
+					certificate: _options.doAdhocSigning ? nil : appCertificate,
+					appName: bundle?.name,
+					appIdentifier: bundle?.bundleIdentifier,
+					appVersion: bundle?.version,
+					appIcon: bundle?.iconFileName
+				) { error in
+					if let error {
+						continuation.resume(throwing: error)
+					} else {
+						Logger.signing.info("[\(self._uuid)] Added to database")
+						continuation.resume()
+					}
+				}
+			}
+		} catch {
+			try? _fileManager.removeItem(at: app)
+			throw error
 		}
 	}
 	
@@ -254,8 +259,8 @@ extension SigningHandler {
 	}
 	
 	private func _removeFiles(for app: URL, from appendingComponent: [String]) async throws {
-		let filesToRemove = appendingComponent.map {
-			app.appendingPathComponent($0)
+		let filesToRemove = try appendingComponent.map {
+			try ArchivePathValidator.destinationURL(base: app, entryPath: $0)
 		}
 		
 		for url in filesToRemove {

--- a/Ksign/Utilities/Handlers/TweakHandler.swift
+++ b/Ksign/Utilities/Handlers/TweakHandler.swift
@@ -71,6 +71,7 @@ class TweakHandler {
 		
 		let baseTmpDir = _fileManager.temporaryDirectory.appendingPathComponent("FeatherTweak_\(UUID().uuidString)")
 		try _fileManager.createDirectoryIfNeeded(at: baseTmpDir)
+		defer { try? _fileManager.removeItem(at: baseTmpDir) }
 		
 		// check for appropriate files, if theres debs
 		// it will extract then add a url, if theres no url, i.e.
@@ -181,11 +182,15 @@ class TweakHandler {
 		// but it somehow works well enough,
 		// do note large lzma's are slow as hell
 		
-		let handler = AR(with: url)
+		let handler = try AR(with: url)
 		let arFiles = try await handler.extract()
 		
 		for arFile in arFiles {
-			let outputPath = uniqueSubDir.appendingPathComponent(arFile.name)
+			let outputPath = try ArchivePathValidator.destinationURL(
+				base: uniqueSubDir,
+				entryPath: arFile.name
+			)
+			try _fileManager.createDirectoryIfNeeded(at: outputPath.deletingLastPathComponent())
 			try arFile.content.write(to: outputPath)
 			
 			if ["data.tar.lzma", "data.tar.gz", "data.tar.xz", "data.tar.bz2"].contains(arFile.name) {

--- a/Ksign/Utilities/Handlers/ZsignHandler.swift
+++ b/Ksign/Utilities/Handlers/ZsignHandler.swift
@@ -47,12 +47,12 @@ final class ZsignHandler {
             appPath: _appUrl.relativePath,
             provisionPath: Storage.shared.getFile(.provision, from: cert)?.path ?? "",
             p12Path: Storage.shared.getFile(.certificate, from: cert)?.path ?? "",
-            p12Password: cert.password ?? "",
+            p12Password: Storage.shared.password(for: cert),
             entitlementsPath: _options.appEntitlementsFile?.path ?? "",
             customIdentifier: _options.appIdentifier ?? "",
             customName: _options.appName ?? "",
             customVersion: _options.appVersion ?? "",
-            removeProvision: !_options.removeProvisioning,
+            removeProvision: _options.removeProvisioning,
             completion: { _, error in
                 self.hadError = error
             }
@@ -67,7 +67,7 @@ final class ZsignHandler {
 			customName: _options.appName ?? "",
 			customVersion: _options.appVersion ?? "",
 			adhoc: true,
-            removeProvision: !_options.removeProvisioning,
+            removeProvision: _options.removeProvisioning,
             completion: { _, error in
                 self.hadError = error
             }

--- a/Ksign/Views/Downloader/DownloaderView.swift
+++ b/Ksign/Views/Downloader/DownloaderView.swift
@@ -11,7 +11,7 @@ import NimbleViews
 import UIKit
 
 struct DownloaderView: View {
-    @StateObject private var downloadManager = IPADownloadManager()
+    @StateObject private var downloadManager = IPADownloadManager.shared
     @StateObject private var libraryManager = DownloadManager.shared
     
     @State private var selectedItem: DownloadItem?

--- a/Ksign/Views/Downloader/ViewModels/IPADownloadManager.swift
+++ b/Ksign/Views/Downloader/ViewModels/IPADownloadManager.swift
@@ -9,6 +9,8 @@ import SwiftUI
 import WebKit
 
 class IPADownloadManager: NSObject, ObservableObject {
+	static let shared = IPADownloadManager()
+
     @Published var downloadItems: [DownloadItem] = []
     
     var activeItems: [DownloadItem] {
@@ -21,6 +23,7 @@ class IPADownloadManager: NSObject, ObservableObject {
     
     private var urlSession: URLSession!
     private var activeDownloads: [Int: String] = [:] // taskIdentifier -> downloadItem.id
+	private let activeDownloadsLock = NSLock()
     
     override init() {
         super.init()
@@ -87,10 +90,13 @@ class IPADownloadManager: NSObject, ObservableObject {
         let fileManager = FileManager.default
         let downloadDirectory = URL.documentsDirectory.appendingPathComponent("Downloads")
         try? fileManager.createDirectoryIfNeeded(at: downloadDirectory)
+		let safeFilename = URL(fileURLWithPath: filename).lastPathComponent.isEmpty
+			? "app.ipa"
+			: URL(fileURLWithPath: filename).lastPathComponent
         
-        let destinationURL = downloadDirectory.appendingPathComponent(filename)
+        let destinationURL = downloadDirectory.appendingPathComponent(safeFilename)
         let item = DownloadItem(
-            title: filename,
+            title: safeFilename,
             url: url,
             localPath: destinationURL,
             isFinished: false,
@@ -99,27 +105,79 @@ class IPADownloadManager: NSObject, ObservableObject {
             bytesDownloaded: 0
         )
         
-        DispatchQueue.main.async {
+        _onMain {
             self.downloadItems.insert(item, at: 0)
         }
         
         let task = urlSession.downloadTask(with: url)
         
-        activeDownloads[task.taskIdentifier] = item.id.uuidString
+        _setActiveDownload(item.id.uuidString, for: task.taskIdentifier)
+		let jobID = "browser-download.\(item.id.uuidString)"
+		JobsManager.shared.start(
+			kind: .download,
+			title: safeFilename,
+			detail: .localized("Downloading"),
+			sourceURL: url,
+			id: jobID,
+			cancel: { [weak self] in
+				self?.cancelDownload(item, updateJob: false)
+			},
+			retry: { [weak self] in
+				self?.startDownload(url: url, filename: safeFilename)
+			}
+		)
         
         task.resume()
     }
     
     
-    func cancelDownload(_ item: DownloadItem) {
+    func cancelDownload(_ item: DownloadItem, updateJob: Bool = true) {
+		if updateJob {
+			JobsManager.shared.cancel("browser-download.\(item.id.uuidString)")
+			return
+		}
         urlSession.getAllTasks { tasks in
             if let task = tasks.first(where: { task in
-                self.activeDownloads[task.taskIdentifier] == item.id.uuidString
+                self._activeDownloadID(for: task.taskIdentifier) == item.id.uuidString
             }) {
                 task.cancel()
             }
         }
     }
+
+	private func _setActiveDownload(_ id: String, for taskIdentifier: Int) {
+		activeDownloadsLock.lock()
+		activeDownloads[taskIdentifier] = id
+		activeDownloadsLock.unlock()
+	}
+
+	private func _activeDownloadID(for taskIdentifier: Int) -> String? {
+		activeDownloadsLock.lock()
+		defer { activeDownloadsLock.unlock() }
+		return activeDownloads[taskIdentifier]
+	}
+
+	private func _removeActiveDownload(for taskIdentifier: Int) {
+		activeDownloadsLock.lock()
+		activeDownloads.removeValue(forKey: taskIdentifier)
+		activeDownloadsLock.unlock()
+	}
+
+	private func _downloadItem(id: String) -> DownloadItem? {
+		var item: DownloadItem?
+		_onMain {
+			item = self.downloadItems.first(where: { $0.id.uuidString == id })
+		}
+		return item
+	}
+
+	private func _onMain(_ operation: @escaping () -> Void) {
+		if Thread.isMainThread {
+			operation()
+		} else {
+			DispatchQueue.main.sync(execute: operation)
+		}
+	}
     
     func handleITMSServicesURL(_ url: URL, completion: @escaping (Result<String, Error>) -> Void) {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
@@ -185,10 +243,12 @@ class IPADownloadManager: NSObject, ObservableObject {
 extension IPADownloadManager: URLSessionDownloadDelegate {
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         let fileManager = FileManager.default
-        guard let downloadItemId = activeDownloads[downloadTask.taskIdentifier],
-              let index = downloadItems.firstIndex(where: { $0.id.uuidString == downloadItemId }) else { return }
-        
-        let item = downloadItems[index]
+        guard
+			let downloadItemID = _activeDownloadID(for: downloadTask.taskIdentifier),
+			let item = _downloadItem(id: downloadItemID)
+		else {
+			return
+		}
         
         do {
             if fileManager.fileExists(atPath: item.localPath.path) {
@@ -207,46 +267,74 @@ extension IPADownloadManager: URLSessionDownloadDelegate {
                     updatedItem.bytesDownloaded = fileSize
                 }
                 
-                if index < self.downloadItems.count {
+                if let index = self.downloadItems.firstIndex(where: { $0.id == item.id }) {
                     self.downloadItems[index] = updatedItem
                 }
-                self.activeDownloads.removeValue(forKey: downloadTask.taskIdentifier)
+                self._removeActiveDownload(for: downloadTask.taskIdentifier)
+				JobsManager.shared.complete(
+					"browser-download.\(item.id.uuidString)",
+					detail: .localized("Saved to Downloads")
+				)
             }
         } catch {
             print("Error saving downloaded file: \(error)")
             DispatchQueue.main.async { [weak self] in
-                self?.downloadItems.remove(at: index)
-                self?.activeDownloads.removeValue(forKey: downloadTask.taskIdentifier)
+				if let index = self?.downloadItems.firstIndex(where: { $0.id == item.id }) {
+					self?.downloadItems.remove(at: index)
+				}
+                self?._removeActiveDownload(for: downloadTask.taskIdentifier)
+				JobsManager.shared.fail(
+					"browser-download.\(item.id.uuidString)",
+					error: error,
+					detail: .localized("Download failed")
+				)
             }
         }
     }
     
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
-        guard let downloadItemId = activeDownloads[downloadTask.taskIdentifier],
-              let index = downloadItems.firstIndex(where: { $0.id.uuidString == downloadItemId }) else { return }
+        guard let downloadItemID = _activeDownloadID(for: downloadTask.taskIdentifier) else { return }
         
         let progress = totalBytesExpectedToWrite > 0 ? Double(totalBytesWritten) / Double(totalBytesExpectedToWrite) : 0
         
         DispatchQueue.main.async { [weak self] in
-            guard let self = self, index < self.downloadItems.count else { return }
+            guard
+				let self,
+				let index = self.downloadItems.firstIndex(where: { $0.id.uuidString == downloadItemID })
+			else {
+				return
+			}
             var item = self.downloadItems[index]
             item.progress = progress
             item.bytesDownloaded = totalBytesWritten
             item.totalBytes = totalBytesExpectedToWrite
             self.downloadItems[index] = item
+			JobsManager.shared.update(
+				"browser-download.\(item.id.uuidString)",
+				progress: progress,
+				detail: item.progressText
+			)
         }
     }
     
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         if let error = error {
-            guard let downloadItemId = activeDownloads[task.taskIdentifier],
-                  let index = downloadItems.firstIndex(where: { $0.id.uuidString == downloadItemId }) else { return }
+            guard let downloadItemID = _activeDownloadID(for: task.taskIdentifier) else { return }
             
             DispatchQueue.main.async { [weak self] in
-                self?.downloadItems.remove(at: index)
-                self?.activeDownloads.removeValue(forKey: task.taskIdentifier)
+				if let index = self?.downloadItems.firstIndex(where: { $0.id.uuidString == downloadItemID }) {
+					self?.downloadItems.remove(at: index)
+				}
+                self?._removeActiveDownload(for: task.taskIdentifier)
+				if (error as NSError).code != NSURLErrorCancelled {
+					JobsManager.shared.fail(
+						"browser-download.\(downloadItemID)",
+						error: error,
+						detail: .localized("Download failed")
+					)
+				}
             }
         }
-        activeDownloads.removeValue(forKey: task.taskIdentifier)
+        _removeActiveDownload(for: task.taskIdentifier)
     }
 }

--- a/Ksign/Views/Files/FilesView.swift
+++ b/Ksign/Views/Files/FilesView.swift
@@ -375,16 +375,18 @@ struct FilesView: View {
         ) { result in
             DispatchQueue.main.async {
                 
+                var extractionError: Error?
                 switch result {
                 case .success:
                     withAnimation {
                         self.viewModel.loadFiles()
                     }
                     
-                case .failure:
+                case .failure(let error):
+                    extractionError = error
                     UIAlertController.showAlertWithOk(title: .localized("Error"), message: .localized("Whoops!, something went wrong when extracting the file. \nMaybe try switching the extraction library in the settings?"))
                 }
-                ExtractManager.shared.finish(item: extractItem)
+                ExtractManager.shared.finish(item: extractItem, error: extractionError)
             }
         }
     }
@@ -404,14 +406,16 @@ struct FilesView: View {
         ) { result in
             DispatchQueue.main.async {
                 
+                var archiveError: Error?
                 switch result {
                 case .success(let ipaFileName):
                     self.viewModel.loadFiles()
                     UIAlertController.showAlertWithOk(title: .localized("Success"), message: .localized("Successfully packaged \(file.name) as \(ipaFileName)"))
                 case .failure(let error):
+                    archiveError = error
                     UIAlertController.showAlertWithOk(title: .localized("Error"), message: .localized("Failed to package IPA: \(error.localizedDescription)"))
                 }
-                ExtractManager.shared.finish(item: extractItem)
+                ExtractManager.shared.finish(item: extractItem, error: archiveError)
             }
         }
     }

--- a/Ksign/Views/Files/Utils/ExtractionService.swift
+++ b/Ksign/Views/Files/Utils/ExtractionService.swift
@@ -69,6 +69,7 @@ class ExtractionService {
                 let appNameWithoutExtension = file.name.replacingOccurrences(of: ".app", with: "")
                 
                 let tempDir = FileManager.default.temporaryDirectory
+					.appendingPathComponent("KsignPackage_\(UUID().uuidString)", isDirectory: true)
                 let payloadDir = tempDir.appendingPathComponent("Payload")
                 let ipaFileName = "\(appNameWithoutExtension).ipa"
                 let zipFilePath = destinationDirectory.appendingPathComponent("\(appNameWithoutExtension).zip")
@@ -76,7 +77,7 @@ class ExtractionService {
                 
                 progressCallback?(0.1)
                 
-                try? FileManager.default.removeItem(at: payloadDir)
+				defer { try? FileManager.default.removeItem(at: tempDir) }
                 try FileManager.default.createDirectory(at: payloadDir, withIntermediateDirectories: true)
                 
                 progressCallback?(0.2)
@@ -96,8 +97,6 @@ class ExtractionService {
                 progressCallback?(0.95)
                 
                 try FileManager.default.moveItem(at: zipFilePath, to: ipaFilePath)
-                
-                try? FileManager.default.removeItem(at: payloadDir)
                 
                 progressCallback?(1.0)
                 completionCallback(.success(ipaFileName))
@@ -133,6 +132,7 @@ class ExtractionService {
         to destinationURL: URL,
         progressCallback: ((Double) -> Void)?
     ) throws {
+		try ArchivePathValidator.validateZipArchive(at: fileURL, destination: destinationURL)
         Zip.addCustomFileExtension("ipa")
         if let progressCallback = progressCallback {
             try Zip.unzipFile(fileURL, destination: destinationURL, overwrite: true, password: nil, progress: progressCallback)
@@ -159,14 +159,19 @@ class ExtractionService {
             let progress = Double(index) / Double(totalEntries)
             progressCallback?(progress)
             
-            let destinationPath = destinationURL.appendingPathComponent(entry.path)
+            let destinationPath = try ArchivePathValidator.destinationURL(
+				base: destinationURL,
+				entryPath: entry.path
+			)
             switch entry.type {
             case .directory:
                 try FileManager.default.createDirectory(at: destinationPath, withIntermediateDirectories: true)
-            default:
+            case .file:
                 let parent = destinationPath.deletingLastPathComponent()
                 try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
                 try archive.extract(entry, to: destinationPath)
+            case .symlink:
+                throw ArchivePathError.unsupportedEntry(entry.path)
             }
         }
     }
@@ -176,7 +181,7 @@ class ExtractionService {
         to destinationURL: URL,
         progressCallback: ((Double) -> Void)?
     ) throws {
-        let debData = try Data(contentsOf: fileURL)
+        let debData = try Data(contentsOf: fileURL, options: .mappedIfSafe)
         let archiveBytes = Array(debData)
         
         progressCallback?(0.2)
@@ -220,7 +225,10 @@ class ExtractionService {
     private static func extractTarEntries(_ entries: [TarEntry], to destinationURL: URL) throws {
         for entry in entries {
             let entryPath = entry.info.name
-            let fullPath = destinationURL.appendingPathComponent(entryPath)
+            let fullPath = try ArchivePathValidator.destinationURL(
+				base: destinationURL,
+				entryPath: entryPath
+			)
             
             if entry.info.type == .directory {
                 try FileManager.default.createDirectory(at: fullPath, withIntermediateDirectories: true)
@@ -252,4 +260,4 @@ enum ExtractionError: LocalizedError {
             return "Extraction failed: \(message)"
         }
     }
-} 
+}

--- a/Ksign/Views/Jobs/JobsView.swift
+++ b/Ksign/Views/Jobs/JobsView.swift
@@ -1,0 +1,150 @@
+import NimbleViews
+import SwiftUI
+
+struct JobsView: View {
+	@StateObject private var _manager = JobsManager.shared
+	@State private var _isDownloadsPresenting = false
+
+	var body: some View {
+		NBNavigationView(.localized("Jobs")) {
+			NBListAdaptable {
+				Section {
+					Button {
+						_isDownloadsPresenting = true
+					} label: {
+						Label(.localized("Open Downloads"), systemImage: "square.and.arrow.down.fill")
+					}
+				}
+
+				if !_manager.activeJobs.isEmpty {
+					NBSection(
+						.localized("Active"),
+						secondary: _manager.activeJobs.count.description
+					) {
+						ForEach(_manager.activeJobs) { job in
+							JobRow(job: job)
+						}
+					}
+				}
+
+				NBSection(
+					.localized("Recent"),
+					secondary: _manager.recentJobs.count.description
+				) {
+					ForEach(_manager.recentJobs) { job in
+						JobRow(job: job)
+					}
+				}
+			}
+			.overlay {
+				if _manager.jobs.isEmpty {
+					if #available(iOS 17, *) {
+						ContentUnavailableView {
+							Label(.localized("No Jobs"), systemImage: "clock.arrow.circlepath")
+						} description: {
+							Text(.localized("Downloads, imports, signing, extraction, and installation activity will appear here."))
+						} actions: {
+							Button(.localized("Open Downloads")) {
+								_isDownloadsPresenting = true
+							}
+						}
+					}
+				}
+			}
+			.toolbar {
+				if !_manager.recentJobs.isEmpty {
+					NBToolbarButton(
+						.localized("Clear"),
+						style: .text,
+						placement: .topBarTrailing
+					) {
+						_manager.clearFinished()
+					}
+				}
+			}
+			.sheet(isPresented: $_isDownloadsPresenting) {
+				DownloaderView()
+			}
+		}
+	}
+}
+
+private struct JobRow: View {
+	@ObservedObject private var _manager = JobsManager.shared
+	let job: JobRecord
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 7) {
+			HStack(spacing: 10) {
+				Image(systemName: job.kind.icon)
+					.foregroundStyle(_color)
+					.frame(width: 24)
+
+				VStack(alignment: .leading, spacing: 2) {
+					Text(job.title)
+						.lineLimit(1)
+					Text(job.detail.isEmpty ? job.kind.title : job.detail)
+						.font(.caption)
+						.foregroundStyle(.secondary)
+						.lineLimit(2)
+				}
+
+				Spacer()
+				_actions
+			}
+
+			if !job.state.isFinished {
+				ProgressView(value: job.progress)
+					.progressViewStyle(.linear)
+			}
+
+			if let error = job.errorMessage {
+				Text(error)
+					.font(.caption)
+					.foregroundStyle(.red)
+					.textSelection(.enabled)
+			}
+		}
+		.padding(.vertical, 4)
+	}
+
+	@ViewBuilder
+	private var _actions: some View {
+		switch job.state {
+		case .queued, .running:
+			if _manager.canCancel(job.id) {
+				Button(role: .destructive) {
+					_manager.cancel(job.id)
+				} label: {
+					Image(systemName: "xmark.circle.fill")
+				}
+				.buttonStyle(.borderless)
+			} else {
+				ProgressView()
+			}
+		case .failed, .cancelled:
+			if _manager.canRetry(job.id) || (job.kind == .download && job.sourceURL != nil) {
+				Button {
+					if !_manager.retry(job.id), let url = job.sourceURL, job.kind == .download {
+						_ = DownloadManager.shared.startDownload(from: url)
+					}
+				} label: {
+					Image(systemName: "arrow.clockwise")
+				}
+				.buttonStyle(.borderless)
+			}
+		case .completed:
+			Image(systemName: "checkmark.circle.fill")
+				.foregroundStyle(.green)
+		}
+	}
+
+	private var _color: Color {
+		switch job.state {
+		case .completed: return .green
+		case .failed: return .red
+		case .cancelled: return .secondary
+		case .queued, .running: return .accentColor
+		}
+	}
+}

--- a/Ksign/Views/Library/Info/LibraryInfoView.swift
+++ b/Ksign/Views/Library/Info/LibraryInfoView.swift
@@ -29,7 +29,12 @@ struct LibraryInfoView: View {
 				
 				Section {
 					Button(.localized("Open App Files"), systemImage: "folder") {
-						UIApplication.open(Storage.shared.getUuidDirectory(for: app)!.toSharedDocumentsURL()!)
+						if
+							let directory = Storage.shared.getUuidDirectory(for: app),
+							let url = directory.toSharedDocumentsURL()
+						{
+							UIApplication.open(url)
+						}
 					}
 				}
 			}

--- a/Ksign/Views/Library/Install/BulkInstallProgressView.swift
+++ b/Ksign/Views/Library/Install/BulkInstallProgressView.swift
@@ -19,13 +19,19 @@ struct BulkInstallProgressView: View {
     @StateObject var installer: ServerInstaller
     @State private var _isWebviewPresenting = false
     @State private var progressTask: Task<Void, Never>?
+	@State private var _jobID: String?
+	@State private var _hasStarted = false
     
     init(app: AppInfoPresentable) {
         self.app = app
         let method = UserDefaults.standard.integer(forKey: "Feather.installationMethod")
         let viewModel = InstallerStatusViewModel(isIdevice: method == 1)
         self._viewModel = StateObject(wrappedValue: viewModel)
-        self._installer = StateObject(wrappedValue: try! ServerInstaller(app: app, viewModel: viewModel))
+        self._installer = StateObject(wrappedValue: ServerInstaller(
+            app: app,
+            viewModel: viewModel,
+            requiresServer: method == 0
+        ))
     }
     
     var body: some View {
@@ -36,18 +42,31 @@ struct BulkInstallProgressView: View {
             SafariRepresentableView(url: installer.pageEndpoint).ignoresSafeArea()
         }
         .onReceive(viewModel.$status) { newStatus in
+			if let jobID = _jobID {
+				JobsManager.shared.update(jobID, progress: viewModel.overallProgress, detail: viewModel.statusLabel)
+				switch newStatus {
+				case .completed:
+					JobsManager.shared.complete(jobID, detail: viewModel.statusLabel)
+				case .broken(let error):
+					JobsManager.shared.fail(jobID, error: error, detail: viewModel.statusLabel)
+				default:
+					break
+				}
+			}
             if case .ready = newStatus {
                 if _serverMethod == 0 {
-                    UIApplication.shared.open(URL(string: installer.iTunesLink)!)
+                    if let url = URL(string: installer.iTunesLink) {
+                        UIApplication.shared.open(url)
+                    }
                 } else if _serverMethod == 1 {
                     _isWebviewPresenting = true
                 }
             }
             
             if case .installing = newStatus {
-                if progressTask == nil {
+                if progressTask == nil, let bundleID = app.identifier {
                     progressTask = startInstallProgressPolling(
-                        bundleID: app.identifier!,
+                        bundleID: bundleID,
                         viewModel: viewModel
                     )
                 }
@@ -67,6 +86,16 @@ struct BulkInstallProgressView: View {
             }
         }
         .onAppear(perform: _install)
+		.onReceive(viewModel.$packageProgress) { progress in
+			if let jobID = _jobID {
+				JobsManager.shared.update(jobID, progress: progress * 0.45, detail: .localized("Packaging"))
+			}
+		}
+		.onReceive(viewModel.$installProgress) { progress in
+			if let jobID = _jobID {
+				JobsManager.shared.update(jobID, progress: 0.55 + (progress * 0.45), detail: .localized("Installing"))
+			}
+		}
         .onAppear {
             BackgroundAudioManager.shared.start()
         }
@@ -78,6 +107,22 @@ struct BulkInstallProgressView: View {
     }
     
     private func _install() {
+		guard !_hasStarted else { return }
+		_hasStarted = true
+
+		_jobID = JobsManager.shared.start(
+			kind: .installation,
+			title: app.name ?? .localized("Unknown App"),
+			detail: .localized("Packaging")
+		)
+        if let error = installer.startupError {
+            if let jobID = _jobID {
+                JobsManager.shared.fail(jobID, error: error, detail: .localized("Installation failed"))
+            }
+            return
+        }
+
+        let appIdentifier = app.identifier
         Task.detached {
             do {
                 let handler = await ArchiveHandler(app: app, viewModel: viewModel)
@@ -91,9 +136,9 @@ struct BulkInstallProgressView: View {
                         viewModel.status = .ready
                     }
                     
-                    if case .installing = await viewModel.status {
+                    if case .installing = await viewModel.status, let bundleID = appIdentifier {
                         let task = await startInstallProgressPolling(
-                            bundleID: app.identifier!,
+                            bundleID: bundleID,
                             viewModel: viewModel
                         )
 
@@ -103,11 +148,14 @@ struct BulkInstallProgressView: View {
                     }
                 } else if await _installationMethod == 1 {
                     let proxy = await InstallationProxy(viewModel: viewModel)
-                    try await proxy.install(at: packageUrl, suspend: app.identifier == Bundle.main.bundleIdentifier!)
+                    try await proxy.install(at: packageUrl, suspend: appIdentifier == Bundle.main.bundleIdentifier)
                 }
                 
             } catch {
                 await MainActor.run {
+					if let jobID = _jobID {
+						JobsManager.shared.fail(jobID, error: error, detail: .localized("Installation failed"))
+					}
                     HeartbeatManager.shared.start(true)
                 }
             }
@@ -148,7 +196,7 @@ struct BulkInstallProgressView: View {
                     break
                 }
 
-                try? await Task.sleep(nanoseconds: 1_000_000) // 1 ms
+                try? await Task.sleep(nanoseconds: 250_000_000)
             }
         }
     }

--- a/Ksign/Views/Library/Install/InstallPreviewView.swift
+++ b/Ksign/Views/Library/Install/InstallPreviewView.swift
@@ -22,6 +22,8 @@ struct InstallPreviewView: View {
 	@AppStorage("Feather.serverMethod") private var _serverMethod: Int = 0
 	@State private var _isWebviewPresenting = false
     @State private var progressTask: Task<Void, Never>?
+	@State private var _jobID: String?
+	@State private var _hasStarted = false
 	
 	var app: AppInfoPresentable
 	@StateObject var viewModel: InstallerStatusViewModel
@@ -31,10 +33,14 @@ struct InstallPreviewView: View {
 	init(app: AppInfoPresentable, isSharing: Bool = false) {
 		self.app = app
 		self.isSharing = isSharing
-        let method = UserDefaults.standard.integer(forKey: "Feather.installationMethod")
+		let method = UserDefaults.standard.integer(forKey: "Feather.installationMethod")
 		let viewModel = InstallerStatusViewModel(isIdevice: method == 1)
 		self._viewModel = StateObject(wrappedValue: viewModel)
-		self._installer = StateObject(wrappedValue: try! ServerInstaller(app: app, viewModel: viewModel))
+		self._installer = StateObject(wrappedValue: ServerInstaller(
+			app: app,
+			viewModel: viewModel,
+			requiresServer: !isSharing && method == 0
+		))
 	}
 	
 	// MARK: Body
@@ -51,18 +57,35 @@ struct InstallPreviewView: View {
 			SafariRepresentableView(url: installer.pageEndpoint).ignoresSafeArea()
 		}
 		.onReceive(viewModel.$status) { newStatus in
+			if let jobID = _jobID {
+				JobsManager.shared.update(
+					jobID,
+					progress: viewModel.overallProgress,
+					detail: viewModel.statusLabel
+				)
+				switch newStatus {
+				case .completed:
+					JobsManager.shared.complete(jobID, detail: viewModel.statusLabel)
+				case .broken(let error):
+					JobsManager.shared.fail(jobID, error: error, detail: viewModel.statusLabel)
+				default:
+					break
+				}
+			}
 			if case .ready = newStatus {
 				if _serverMethod == 0 {
-					UIApplication.shared.open(URL(string: installer.iTunesLink)!)
+					if let url = URL(string: installer.iTunesLink) {
+						UIApplication.shared.open(url)
+					}
 				} else if _serverMethod == 1 {
 					_isWebviewPresenting = true
 				}
 			}
             
             if case .installing = newStatus {
-                if progressTask == nil {
+                if progressTask == nil, let bundleID = app.identifier {
                     progressTask = startInstallProgressPolling(
-                        bundleID: app.identifier!,
+                        bundleID: bundleID,
                         viewModel: viewModel
                     )
                 }
@@ -82,6 +105,16 @@ struct InstallPreviewView: View {
             }
 		}
 		.onAppear(perform: _install)
+		.onReceive(viewModel.$packageProgress) { progress in
+			if let jobID = _jobID {
+				JobsManager.shared.update(jobID, progress: progress * 0.45, detail: .localized("Packaging"))
+			}
+		}
+		.onReceive(viewModel.$installProgress) { progress in
+			if let jobID = _jobID {
+				JobsManager.shared.update(jobID, progress: 0.55 + (progress * 0.45), detail: .localized("Installing"))
+			}
+		}
 		.onAppear {
 			BackgroundAudioManager.shared.start()
 		}
@@ -102,7 +135,10 @@ struct InstallPreviewView: View {
 	}
 	
 	private func _install() {
-        guard isSharing || app.identifier != Bundle.main.bundleIdentifier! || _installationMethod == 1 else {
+		guard !_hasStarted else { return }
+		_hasStarted = true
+
+        guard isSharing || app.identifier != Bundle.main.bundleIdentifier || _installationMethod == 1 else {
             UIAlertController.showAlertWithOk(
                 title: .localized("Install"),
                 message: .localized("You cannot update ‘%@‘ with itself, please use an alternative tool to update it.", arguments: Bundle.main.name)
@@ -110,6 +146,24 @@ struct InstallPreviewView: View {
             return
         }
 
+		_jobID = JobsManager.shared.start(
+			kind: isSharing ? .archive : .installation,
+			title: app.name ?? .localized("Unknown App"),
+			detail: .localized("Packaging")
+		)
+
+		if let error = installer.startupError {
+			if let jobID = _jobID {
+				JobsManager.shared.fail(jobID, error: error, detail: .localized("Installation failed"))
+			}
+			UIAlertController.showAlertWithOk(
+				title: .localized("Install"),
+				message: error.localizedDescription
+			)
+			return
+		}
+
+		let appIdentifier = app.identifier
 		Task.detached {
 			do {
 				let handler = await ArchiveHandler(app: app, viewModel: viewModel)
@@ -124,9 +178,9 @@ struct InstallPreviewView: View {
                             viewModel.status = .ready
                         }
                         
-                        if case .installing = await viewModel.status {
+                        if case .installing = await viewModel.status, let bundleID = appIdentifier {
                             let task = await startInstallProgressPolling(
-                                bundleID: app.identifier!,
+                                bundleID: bundleID,
                                 viewModel: viewModel
                             )
 
@@ -137,18 +191,24 @@ struct InstallPreviewView: View {
                     }
                     else if await _installationMethod == 1 {
                         let handler = await InstallationProxy(viewModel: viewModel)
-                        try await handler.install(at: packageUrl, suspend: app.identifier == Bundle.main.bundleIdentifier!)
+                        try await handler.install(at: packageUrl, suspend: appIdentifier == Bundle.main.bundleIdentifier)
                     }
 				} else {
 					let package = try await handler.moveToArchive(packageUrl, shouldOpen: !_useShareSheet)
 					
 					if await !_useShareSheet {
 						await MainActor.run {
+							if let jobID = _jobID {
+								JobsManager.shared.complete(jobID, detail: .localized("Archive completed"))
+							}
 							dismiss()
 						}
 					} else {
 						if let package {
 							await MainActor.run {
+								if let jobID = _jobID {
+									JobsManager.shared.complete(jobID, detail: .localized("Archive completed"))
+								}
 								dismiss()
 								UIActivityViewController.show(activityItems: [package])
 							}
@@ -158,6 +218,9 @@ struct InstallPreviewView: View {
 			} catch {
                 await progressTask?.cancel()
 				await MainActor.run {
+					if let jobID = _jobID {
+						JobsManager.shared.fail(jobID, error: error, detail: isSharing ? .localized("Archive failed") : .localized("Installation failed"))
+					}
 					UIAlertController.showAlertWithOk(
 						title: .localized("Install"),
 						message: error.localizedDescription,
@@ -204,7 +267,7 @@ struct InstallPreviewView: View {
                         break
                     }
 
-                    try? await Task.sleep(nanoseconds: 1_000_000) // 1 ms
+                    try? await Task.sleep(nanoseconds: 250_000_000)
                 }
             }
         }

--- a/Ksign/Views/Settings/About/AboutNyaView.swift
+++ b/Ksign/Views/Settings/About/AboutNyaView.swift
@@ -20,8 +20,13 @@ struct AboutNyaView: View {
 		NBList(.localized("About")) {
             Section {
                 VStack {
-                    Image(uiImage: (UIImage(named: Bundle.main.iconFileName ?? ""))! )
-                        .appIconStyle(size: 72)
+					if let image = UIImage(named: Bundle.main.iconFileName ?? "") {
+						Image(uiImage: image)
+							.appIconStyle(size: 72)
+					} else {
+						Image(systemName: "app.fill")
+							.appIconStyle(size: 72)
+					}
                     
                     Text(Bundle.main.exec)
                         .font(.largeTitle)
@@ -104,7 +109,7 @@ extension AboutNyaView {
 		FRIconCellView(
 			title: name ?? github,
 			subtitle: desc ?? "",
-			iconUrl: URL(string: "https://github.com/\(github).png")!,
+			iconUrl: URL(string: "https://github.com/\(github).png"),
 			trailing: AnyView(
 				Image(systemName: "arrow.up.right")
 					.foregroundStyle(.secondary)

--- a/Ksign/Views/Settings/About/AboutView.swift
+++ b/Ksign/Views/Settings/About/AboutView.swift
@@ -43,7 +43,7 @@ extension AboutView {
 		FRIconCellView(
 			title: name ?? github,
 			subtitle: desc ?? "",
-			iconUrl: URL(string: "https://github.com/\(github).png")!,
+			iconUrl: URL(string: "https://github.com/\(github).png"),
 			trailing: AnyView(
 				Image(systemName: "arrow.up.right")
 					.foregroundStyle(.secondary)

--- a/Ksign/Views/Settings/Appearance/AppearanceView.swift
+++ b/Ksign/Views/Settings/Appearance/AppearanceView.swift
@@ -101,8 +101,7 @@ struct AppearanceView: View {
 	@ViewBuilder
 	private func _libraryPreview() -> some View {
 		HStack(spacing: 9) {
-			Image(uiImage: (UIImage(named: Bundle.main.iconFileName ?? ""))! )
-				.appIconStyle(size: 57)
+			_appIcon(size: 57)
 			
 			NBTitleWithSubtitleView(
 				title: Bundle.main.name,
@@ -122,8 +121,7 @@ struct AppearanceView: View {
     private func _storePreview() -> some View {
         VStack {
             HStack(spacing: 9) {
-                Image(uiImage: (UIImage(named: Bundle.main.iconFileName ?? ""))! )
-                    .appIconStyle(size: 57)
+                _appIcon(size: 57)
                 
                 NBTitleWithSubtitleView(
                     title: Bundle.main.name,
@@ -156,6 +154,17 @@ struct AppearanceView: View {
 				subtitle: .localized("This is the current accent color"),
 				linelimit: 0
 			)
+		}
+	}
+
+	@ViewBuilder
+	private func _appIcon(size: CGFloat) -> some View {
+		if let image = UIImage(named: Bundle.main.iconFileName ?? "") {
+			Image(uiImage: image)
+				.appIconStyle(size: size)
+		} else {
+			Image(systemName: "app.fill")
+				.appIconStyle(size: size)
 		}
 	}
 }

--- a/Ksign/Views/Settings/Certificates/CertificatesView.swift
+++ b/Ksign/Views/Settings/Certificates/CertificatesView.swift
@@ -11,7 +11,7 @@ import UIKit
 
 // MARK: - View
 struct CertificatesView: View {
-	@AppStorage("feather.selectedCert") private var _storedSelectedCert: Int = 0
+	@AppStorage(CertificateSelection.uuidKey) private var _storedSelectedCert: String = ""
 	
 	@State private var _isAddingPresenting = false
 	@State private var _isSelectedInfoPresenting: CertificatePair?
@@ -24,20 +24,20 @@ struct CertificatesView: View {
 	) private var certificates: FetchedResults<CertificatePair>
 	
 	//
-	private var _bindingSelectedCert: Binding<Int>?
-	private var _selectedCertBinding: Binding<Int> {
+	private var _bindingSelectedCert: Binding<String>?
+	private var _selectedCertBinding: Binding<String> {
 		_bindingSelectedCert ?? $_storedSelectedCert
 	}
 	
-	init(selectedCert: Binding<Int>? = nil) {
+	init(selectedCert: Binding<String>? = nil) {
 		self._bindingSelectedCert = selectedCert
 	}
 	
 	// MARK: Body
 	var body: some View {
 		NBGrid {
-			ForEach(Array(certificates.enumerated()), id: \.element.uuid) { index, cert in
-				_cellButton(for: cert, at: index)
+			ForEach(certificates, id: \.uuid) { cert in
+				_cellButton(for: cert)
 			}
 		}
 		.navigationTitle(.localized("Certificates"))
@@ -81,6 +81,18 @@ struct CertificatesView: View {
 				}
 			}
 		}
+		.onAppear {
+			_selectedCertBinding.wrappedValue = CertificateSelection.selected(
+				in: Array(certificates),
+				uuid: _selectedCertBinding.wrappedValue
+			)?.uuid ?? ""
+		}
+		.onChange(of: certificates.count) { _ in
+			_selectedCertBinding.wrappedValue = CertificateSelection.selected(
+				in: Array(certificates),
+				uuid: _selectedCertBinding.wrappedValue
+			)?.uuid ?? ""
+		}
 		.sheet(item: $_isSelectedInfoPresenting) { cert in
 			CertificatesInfoView(cert: cert)
 		}
@@ -93,9 +105,9 @@ struct CertificatesView: View {
 
 extension CertificatesView {
 	@ViewBuilder
-	private func _cellButton(for cert: CertificatePair, at index: Int) -> some View {
+	private func _cellButton(for cert: CertificatePair) -> some View {
 		Button {
-			_selectedCertBinding.wrappedValue = index
+			_selectedCertBinding.wrappedValue = cert.uuid ?? ""
 		} label: {
 			CertificatesCellView(
 				cert: cert
@@ -108,7 +120,7 @@ extension CertificatesView {
 			.overlay(
 				RoundedRectangle(cornerRadius: _cornerRadius)
 					.strokeBorder(
-						_selectedCertBinding.wrappedValue == index ? Color.accentColor : Color.clear,
+						_selectedCertBinding.wrappedValue == (cert.uuid ?? "") ? Color.accentColor : Color.clear,
 						lineWidth: 2
 					)
 			)

--- a/Ksign/Views/Settings/Reset/ResetView.swift
+++ b/Ksign/Views/Settings/Reset/ResetView.swift
@@ -86,7 +86,7 @@ extension ResetView {
 		Section {
 			Button("Reset Sources", systemImage: "xmark.circle") {
 				Self.resetAlert(
-					title: "Reset Signed Apps",
+					title: "Reset Sources",
 					message: Storage.shared.countContent(for: AltSource.self)
 				) {
 					Self.resetSources()
@@ -168,30 +168,42 @@ extension ResetView {
 	}
 	
 	static func resetSources() {
+		SourceIntelligenceManager.shared.clearAll()
 		Storage.shared.clearContext(request: AltSource.fetchRequest())
 	}
 	
 	static func deleteSignedApps() {
 		Storage.shared.clearContext(request: Signed.fetchRequest())
+		SourceIntelligenceManager.shared.invalidateLocalVersionSnapshot()
 		try? FileManager.default.removeFileIfNeeded(at: FileManager.default.signed)
 	}
 	
 	static func deleteImportedApps() {
 		Storage.shared.clearContext(request: Imported.fetchRequest())
+		SourceIntelligenceManager.shared.invalidateLocalVersionSnapshot()
 		try? FileManager.default.removeFileIfNeeded(at: FileManager.default.unsigned)
 	}
 	
 	static func resetCertificates(resetAll: Bool = false) {
-		if !resetAll { UserDefaults.standard.set(0, forKey: "feather.selectedCert") }
+		if !resetAll { CertificateSelection.clear() }
+		let request: NSFetchRequest<CertificatePair> = CertificatePair.fetchRequest()
+		for certificate in (try? Storage.shared.context.fetch(request)) ?? [] {
+			if let uuid = certificate.uuid {
+				CertificatePasswordStore.deletePassword(for: uuid)
+			}
+		}
 		Storage.shared.clearContext(request: CertificatePair.fetchRequest())
 		try? FileManager.default.removeFileIfNeeded(at: FileManager.default.certificates)
 	}
 	
 	static func resetUserDefaults() {
-		UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+		if let bundleIdentifier = Bundle.main.bundleIdentifier {
+			UserDefaults.standard.removePersistentDomain(forName: bundleIdentifier)
+		}
 	}
 	
 	static func resetAll() {
+		JobsManager.shared.clearAll()
 		clearWorkCache()
 		clearNetworkCache()
 		resetSources()

--- a/Ksign/Views/Settings/SettingsDonationCellView.swift
+++ b/Ksign/Views/Settings/SettingsDonationCellView.swift
@@ -38,7 +38,14 @@ struct SettingsDonationCellView: View {
 	@ViewBuilder
 	private func _title() -> some View {
 		VStack(alignment: .center, spacing: 12) {
-            Image(uiImage: (UIImage(named: "Kana_love"))!).resizable().frame(width: 60, height: 60)
+			if let image = UIImage(named: "Kana_love") {
+				Image(uiImage: image)
+					.resizable()
+					.frame(width: 60, height: 60)
+			} else {
+				Image(systemName: "heart.fill")
+					.font(.system(size: 48))
+			}
 			
 			Text(.localized("Donations"))
 				.font(.title)

--- a/Ksign/Views/Settings/SettingsView.swift
+++ b/Ksign/Views/Settings/SettingsView.swift
@@ -10,7 +10,7 @@ import NimbleViews
 
 // MARK: - View
 struct SettingsView: View {
-    @AppStorage("feather.selectedCert") private var _storedSelectedCert: Int = 0
+    @AppStorage(CertificateSelection.uuidKey) private var _storedSelectedCert: String = ""
     @FetchRequest(
         entity: CertificatePair.entity(),
         sortDescriptors: [NSSortDescriptor(keyPath: \CertificatePair.date, ascending: false)],
@@ -18,13 +18,7 @@ struct SettingsView: View {
     ) private var _certificates: FetchedResults<CertificatePair>
     
     private var selectedCertificate: CertificatePair? {
-        guard
-            _storedSelectedCert >= 0,
-            _storedSelectedCert < _certificates.count
-        else {
-            return nil
-        }
-        return _certificates[_storedSelectedCert]
+        CertificateSelection.selected(in: Array(_certificates), uuid: _storedSelectedCert)
     }
     
     
@@ -124,10 +118,14 @@ extension SettingsView {
 	private func _directories() -> some View {
 		NBSection(.localized("Misc")) {
 			Button(.localized("Open Documents"), systemImage: "folder") {
-				UIApplication.open(URL.documentsDirectory.toSharedDocumentsURL()!)
+				if let url = URL.documentsDirectory.toSharedDocumentsURL() {
+					UIApplication.open(url)
+				}
 			}
 			Button(.localized("Open Archives"), systemImage: "folder") {
-				UIApplication.open(FileManager.default.archives.toSharedDocumentsURL()!)
+				if let url = FileManager.default.archives.toSharedDocumentsURL() {
+					UIApplication.open(url)
+				}
 			}
 		} footer: {
 			Text(.localized("All of Ksign files except certificates are contained in the documents directory, here are some quick links to these."))

--- a/Ksign/Views/Signing/BulkSigningView.swift
+++ b/Ksign/Views/Signing/BulkSigningView.swift
@@ -24,17 +24,19 @@ struct BulkSigningView: View {
 	) private var certificates: FetchedResults<CertificatePair>
 	
 	private func _selectedCert() -> CertificatePair? {
-		guard certificates.indices.contains(_temporaryCertificate) else { return nil }
-		return certificates[_temporaryCertificate]
+		CertificateSelection.selected(in: Array(certificates), uuid: _temporaryCertificate)
 	}
 	
 	@StateObject private var _optionsManager = OptionsManager.shared
 	@State private var _configs: [AppSignConfig]
-	@State private var _temporaryCertificate: Int
+	@State private var _temporaryCertificate: String
 	@State private var _isAltPickerPresenting = false
 	@State private var _isFilePickerPresenting = false
 	@State private var _isImagePickerPresenting = false
 	@State private var _isSigning = false
+	@State private var _completedCount = 0
+	@State private var _bulkErrorMessage = ""
+	@State private var _isBulkErrorPresenting = false
 	@State private var _selectedPhoto: PhotosPickerItem? = nil
 	@State private var _editingConfigId: String?
 	
@@ -43,7 +45,7 @@ struct BulkSigningView: View {
 
 	init(apps: [AppInfoPresentable]) {
 		self.apps = apps
-		let storedCert = UserDefaults.standard.integer(forKey: "feather.selectedCert")
+		let storedCert = UserDefaults.standard.string(forKey: CertificateSelection.uuidKey) ?? ""
 		__temporaryCertificate = State(initialValue: storedCert)
 		
 		let defaultOptions = OptionsManager.shared.options
@@ -63,10 +65,20 @@ struct BulkSigningView: View {
 				}
 			}
 			.safeAreaInset(edge: .bottom) {
-				Button {
-					_start()
-				} label: {
-					NBSheetButton(title: .localized("Start Signing"))
+				VStack(spacing: 8) {
+					if _isSigning {
+						ProgressView(value: Double(_completedCount), total: Double(max(_configs.count, 1)))
+							.padding(.horizontal)
+						Text("\(_completedCount) / \(_configs.count)")
+							.font(.caption)
+							.foregroundStyle(.secondary)
+					}
+					Button {
+						_start()
+					} label: {
+						NBSheetButton(title: _isSigning ? .localized("Signing") : .localized("Start Signing"))
+					}
+					.disabled(_isSigning)
 				}
 			}
 			.toolbar {
@@ -119,6 +131,16 @@ struct BulkSigningView: View {
 			}
 			.disabled(_isSigning)
 			.animation(.smooth, value: _isSigning)
+			.alert(.localized("Bulk Signing"), isPresented: $_isBulkErrorPresenting) {
+				Button(.localized("OK"), role: .cancel) {}
+			} message: {
+				Text(_bulkErrorMessage)
+			}
+			.onAppear {
+				if _temporaryCertificate.isEmpty {
+					_temporaryCertificate = _selectedCert()?.uuid ?? ""
+				}
+			}
 		}
 	}
 }
@@ -252,24 +274,43 @@ extension BulkSigningView {
 		let generator = UIImpactFeedbackGenerator(style: .light)
 		generator.impactOccurred()
 		_isSigning = true
+		_completedCount = 0
 
-		
-		for config in _configs {
-			FR.signPackageFile(
-				config.app,
-				using: config.options,
-				icon: config.icon,
-				certificate: _selectedCert()
-			) { [self] error in
-				if let error {
-					UIAlertController.showAlertWithOk(title: "Error", message: error.localizedDescription)
+		let configs = _configs
+		let certificate = _selectedCert()
+		Task.detached {
+			var errors: [String] = []
+
+			for config in configs {
+				do {
+					try await FR.signPackageFile(
+						config.app,
+						using: config.options,
+						icon: config.icon,
+						certificate: certificate
+					)
+				} catch {
+					let appName = await MainActor.run {
+						config.app.name ?? String.localized("Unknown")
+					}
+					errors.append("\(appName): \(error.localizedDescription)")
 				}
-				DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-					NotificationCenter.default.post(name: NSNotification.Name("ksign.bulkSigningFinished"), object: nil)
+
+				await MainActor.run {
+					_completedCount += 1
 				}
-				dismiss()
+			}
+
+			await MainActor.run {
+				NotificationCenter.default.post(name: NSNotification.Name("ksign.bulkSigningFinished"), object: nil)
+				if errors.isEmpty {
+					dismiss()
+				} else {
+					_isSigning = false
+					_bulkErrorMessage = errors.joined(separator: "\n")
+					_isBulkErrorPresenting = true
+				}
 			}
 		}
-
 	}
 }

--- a/Ksign/Views/Signing/SigningView.swift
+++ b/Ksign/Views/Signing/SigningView.swift
@@ -17,7 +17,7 @@ struct SigningView: View {
 	@StateObject private var _optionsManager = OptionsManager.shared
 	
 	@State private var _temporaryOptions: Options = OptionsManager.shared.options
-	@State private var _temporaryCertificate: Int
+	@State private var _temporaryCertificate: String
 	@State private var _isAltPickerPresenting = false
 	@State private var _isFilePickerPresenting = false
 	@State private var _isImagePickerPresenting = false
@@ -36,8 +36,7 @@ struct SigningView: View {
 	) private var certificates: FetchedResults<CertificatePair>
 	
 	private func _selectedCert() -> CertificatePair? {
-		guard certificates.indices.contains(_temporaryCertificate) else { return nil }
-		return certificates[_temporaryCertificate]
+		CertificateSelection.selected(in: Array(certificates), uuid: _temporaryCertificate)
 	}
 	
 	private func _getCertAppID() -> String? {
@@ -57,7 +56,7 @@ struct SigningView: View {
 	init(app: AppInfoPresentable, signAndInstall: Bool = false) {
 		self.app = app
 		self.signAndInstall = signAndInstall
-		let storedCert = UserDefaults.standard.integer(forKey: "feather.selectedCert")
+		let storedCert = UserDefaults.standard.string(forKey: CertificateSelection.uuidKey) ?? ""
 		__temporaryCertificate = State(initialValue: storedCert)
 	}
 		
@@ -127,6 +126,9 @@ struct SigningView: View {
 			.animation(.smooth, value: _isSigning)
 		}
 		.onAppear {
+			if _temporaryCertificate.isEmpty {
+				_temporaryCertificate = _selectedCert()?.uuid ?? ""
+			}
 			// ppq protection
 			if
 				_optionsManager.options.ppqProtection,

--- a/Ksign/Views/Sources/Apps/SourceAppsCellView.swift
+++ b/Ksign/Views/Sources/Apps/SourceAppsCellView.swift
@@ -14,6 +14,7 @@ import NukeUI
 // thats a whole pharaghraph of codes
 struct SourceAppsCellView: View {
     @AppStorage("Feather.storeCellAppearance") private var _storeCellAppearance: Int = 0
+    @ObservedObject private var _intelligence = SourceIntelligenceManager.shared
     
     var source: ASRepository
     var app: ASRepository.App
@@ -38,6 +39,18 @@ struct SourceAppsCellView: View {
                     }
                 }
                 DownloadButtonView(app: app)
+            }
+            .overlay(alignment: .topTrailing) {
+                if _intelligence.isUpdateAvailable(for: app) {
+                    Text(.localized("Update"))
+                        .font(.caption2.bold())
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 3)
+                        .background(.orange)
+                        .clipShape(Capsule())
+                        .offset(y: -6)
+                }
             }
             
             if

--- a/Ksign/Views/Sources/Apps/SourceAppsView.swift
+++ b/Ksign/Views/Sources/Apps/SourceAppsView.swift
@@ -110,8 +110,8 @@ struct SourceAppsView: View {
             Divider()
             
             Button(.localized("Copy"), systemImage: "doc.on.doc") {
-                UIPasteboard.general.string = object.map {
-                    $0.sourceURL!.absoluteString
+                UIPasteboard.general.string = object.compactMap {
+                    $0.sourceURL?.absoluteString
                 }.joined(separator: "\n")
                 UINotificationFeedbackGenerator().notificationOccurred(.success)
             }
@@ -222,10 +222,23 @@ extension View {
         item: Binding<Item?>,
         @ViewBuilder destination: @escaping (Item) -> Destination
     ) -> some View {
-        if #available(iOS 17, *) {
-            self.navigationDestination(item: item, destination: destination)
-        } else {
-            self
-        }
-    }
+		if #available(iOS 17, *) {
+			self.navigationDestination(item: item, destination: destination)
+		} else {
+			self.navigationDestination(
+				isPresented: Binding(
+					get: { item.wrappedValue != nil },
+					set: { isPresented in
+						if !isPresented {
+							item.wrappedValue = nil
+						}
+					}
+				)
+			) {
+				if let value = item.wrappedValue {
+					destination(value)
+				}
+			}
+		}
+	}
 }

--- a/Ksign/Views/Sources/Apps/UIKit/SourceAppsTableRepresentableView.swift
+++ b/Ksign/Views/Sources/Apps/UIKit/SourceAppsTableRepresentableView.swift
@@ -23,11 +23,7 @@ struct SourceAppsTableRepresentableView: UIViewRepresentable {
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "AppCell")
         tableView.register(UITableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: "SectionHeader")
         
-        if #available(iOS 17, *) {
-            tableView.allowsSelection = true
-        } else {
-            tableView.allowsSelection = false
-        }
+        tableView.allowsSelection = true
         
         if
             let firstSource = sources.first,
@@ -173,8 +169,8 @@ extension SourceAppsTableRepresentableView { class Coordinator: NSObject, UITabl
             let sorted = filtered.sorted {
                 let n1 = $0.app.name ?? ""
                 let n2 = $1.app.name ?? ""
-                let comparison = n1.localizedCaseInsensitiveCompare(n2) == .orderedAscending
-                return sortAscending ? comparison : !comparison
+                let comparison = n1.localizedCaseInsensitiveCompare(n2)
+                return sortAscending ? comparison == .orderedAscending : comparison == .orderedDescending
             }
             _groupedAppsByNameFirstLetter = Dictionary(grouping: sorted) {
                 let first = $0.app.name?.trimmingCharacters(in: .whitespacesAndNewlines).first?.uppercased() ?? "#"
@@ -231,18 +227,16 @@ extension SourceAppsTableRepresentableView { class Coordinator: NSObject, UITabl
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if #available(iOS 17, *) {
-            tableView.deselectRow(at: indexPath, animated: true)
-            
-            let entry: (source: ASRepository, app: ASRepository.App)
-            switch sortOption {
-            case .default: entry = _sortedApps[indexPath.row]
-            case .name: entry = _groupedAppsByNameFirstLetter[_sortedSectionTitles[indexPath.section]]?[indexPath.row] ?? _sortedApps[indexPath.row]
-            case .date: entry = _groupedAppsByDate[_sortedSectionTitles[indexPath.section]]?[indexPath.row] ?? _sortedApps[indexPath.row]
-            }
-            
-            onSelect(SourceAppsView.SourceAppRoute(source: entry.source, app: entry.app))
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        let entry: (source: ASRepository, app: ASRepository.App)
+        switch sortOption {
+        case .default: entry = _sortedApps[indexPath.row]
+        case .name: entry = _groupedAppsByNameFirstLetter[_sortedSectionTitles[indexPath.section]]?[indexPath.row] ?? _sortedApps[indexPath.row]
+        case .date: entry = _groupedAppsByDate[_sortedSectionTitles[indexPath.section]]?[indexPath.row] ?? _sortedApps[indexPath.row]
         }
+
+        onSelect(SourceAppsView.SourceAppRoute(source: entry.source, app: entry.app))
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/Ksign/Views/Sources/SourceIntelligenceView.swift
+++ b/Ksign/Views/Sources/SourceIntelligenceView.swift
@@ -1,0 +1,155 @@
+import AltSourceKit
+import NimbleViews
+import SwiftUI
+
+struct SourceIntelligenceView: View {
+	@StateObject private var _intelligence = SourceIntelligenceManager.shared
+	@StateObject private var _viewModel = SourcesViewModel.shared
+
+	@FetchRequest(
+		entity: AltSource.entity(),
+		sortDescriptors: [NSSortDescriptor(keyPath: \AltSource.name, ascending: true)],
+		animation: .snappy
+	) private var _sources: FetchedResults<AltSource>
+
+	private var _favorites: [AltSource] {
+		_sources.filter { _intelligence.insight(for: $0).isFavorite }
+	}
+
+	private var _attentionNeeded: [AltSource] {
+		_sources.filter {
+			let insight = _intelligence.insight(for: $0)
+			return insight.health == .degraded
+				|| insight.health == .offline
+				|| insight.trust == .untrusted
+				|| insight.updateCount > 0
+				|| insight.contentChanged
+		}
+	}
+
+	var body: some View {
+		NBList(.localized("Source Intelligence")) {
+			NBSection(.localized("Summary")) {
+				LabeledContent(.localized("Available Updates"), value: _intelligence.updateBundleIDs.count.description)
+				LabeledContent(.localized("Favorites"), value: _favorites.count.description)
+				LabeledContent(.localized("Needs Attention"), value: _attentionNeeded.count.description)
+			}
+
+			if !_favorites.isEmpty {
+				NBSection(.localized("Favorites")) {
+					ForEach(_favorites) { source in
+						_sourceLink(source)
+					}
+				}
+			}
+
+			if !_attentionNeeded.isEmpty {
+				NBSection(.localized("Needs Attention")) {
+					ForEach(_attentionNeeded) { source in
+						_sourceLink(source)
+					}
+				}
+			}
+
+			NBSection(.localized("All Sources")) {
+				ForEach(_sources) { source in
+					_sourceLink(source)
+				}
+			}
+		}
+		.refreshable {
+			await _viewModel.fetchSources(_sources, refresh: true)
+		}
+	}
+
+	private func _sourceLink(_ source: AltSource) -> some View {
+		NavigationLink {
+			SourceAppsView(object: [source], viewModel: _viewModel)
+		} label: {
+			SourceIntelligenceRow(source: source)
+		}
+		.buttonStyle(.plain)
+	}
+}
+
+struct SourceIntelligenceRow: View {
+	@ObservedObject private var _intelligence = SourceIntelligenceManager.shared
+	let source: AltSource
+
+	private var _insight: SourceInsight {
+		_intelligence.insight(for: source)
+	}
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 6) {
+			HStack {
+				Label(source.name ?? .localized("Unknown"), systemImage: _insight.health.icon)
+					.foregroundStyle(_healthColor)
+				Spacer()
+				if _insight.isFavorite {
+					Image(systemName: "star.fill")
+						.foregroundStyle(.yellow)
+				}
+			}
+
+			HStack(spacing: 12) {
+				Label(_insight.trust.title, systemImage: _insight.trust.icon)
+				Label("\(_insight.appCount)", systemImage: "square.grid.2x2")
+				if _insight.updateCount > 0 {
+					Label("\(_insight.updateCount)", systemImage: "arrow.down.app.fill")
+						.foregroundStyle(.orange)
+				}
+				if _insight.contentChanged {
+					Label(.localized("Changed"), systemImage: "sparkles")
+						.foregroundStyle(.blue)
+				}
+				if let lastChecked = _insight.lastChecked {
+					Label(
+						lastChecked.formatted(date: .abbreviated, time: .shortened),
+						systemImage: "clock"
+					)
+				}
+			}
+			.font(.caption)
+			.foregroundStyle(.secondary)
+
+			if let error = _insight.lastError {
+				Text(error)
+					.font(.caption)
+					.foregroundStyle(.red)
+					.lineLimit(2)
+			}
+		}
+		.contextMenu {
+			Button {
+				_intelligence.toggleFavorite(source)
+			} label: {
+				Label(
+					_insight.isFavorite ? .localized("Remove Favorite") : .localized("Favorite"),
+					systemImage: _insight.isFavorite ? "star.slash" : "star"
+				)
+			}
+
+			Menu(.localized("Trust"), systemImage: "checkmark.shield") {
+				Button(.localized("Trusted")) {
+					_intelligence.setTrust(.trusted, for: source)
+				}
+				Button(.localized("Untrusted")) {
+					_intelligence.setTrust(.untrusted, for: source)
+				}
+				Button(.localized("Unreviewed")) {
+					_intelligence.setTrust(.unknown, for: source)
+				}
+			}
+		}
+	}
+
+	private var _healthColor: Color {
+		switch _insight.health {
+		case .healthy: return .green
+		case .degraded: return .orange
+		case .offline: return .red
+		case .unchecked: return .secondary
+		}
+	}
+}

--- a/Ksign/Views/Sources/SourcesAddView.swift
+++ b/Ksign/Views/Sources/SourcesAddView.swift
@@ -43,8 +43,8 @@ struct SourcesAddView: View {
 					}
 					
 					Button(.localized("Export"), systemImage: "doc.on.clipboard") {
-						UIPasteboard.general.string = Storage.shared.getSources().map {
-							$0.sourceURL!.absoluteString
+						UIPasteboard.general.string = Storage.shared.getSources().compactMap {
+							$0.sourceURL?.absoluteString
 						}.joined(separator: "\n")
 						UINotificationFeedbackGenerator().notificationOccurred(.success)
 						UIAlertController.showAlertWithOk(title: .localized("Success"), message: .localized("All sources copied to clipboard."))
@@ -63,8 +63,10 @@ struct SourcesAddView: View {
 						placement: .confirmationAction,
 						isDisabled: _sourceURL.isEmpty
 					) {
-						FR.handleSource(_sourceURL) {
-							dismiss()
+						FR.handleSource(_sourceURL) { success in
+							if success {
+								dismiss()
+							}
 						}
 					}
 				} else {
@@ -80,12 +82,22 @@ struct SourcesAddView: View {
 		_ code: String?,
 		competion: @escaping () -> Void
 	) {
-		guard let code else { return }
+		guard let code else {
+			_isImporting = false
+			return
+		}
 		
 		let handler = ASDeobfuscator(with: code)
 		let repoUrls = handler.decode().compactMap { URL(string: $0) }
 
-		guard !repoUrls.isEmpty else { return }
+		guard !repoUrls.isEmpty else {
+			_isImporting = false
+			UIAlertController.showAlertWithOk(
+				title: .localized("Error"),
+				message: .localized("No valid source URLs were found.")
+			)
+			return
+		}
 		
 		actor RepositoryCollector {
 			private var repositories: [URL: ASRepository] = [:]
@@ -130,8 +142,25 @@ struct SourcesAddView: View {
 			let repositories = await collector.getAllRepositories()
 			
 			await MainActor.run {
-				Storage.shared.addSources(repos: repositories) { _ in
-					competion()
+				guard !repositories.isEmpty else {
+					_isImporting = false
+					UIAlertController.showAlertWithOk(
+						title: .localized("Error"),
+						message: .localized("No sources could be imported.")
+					)
+					return
+				}
+
+				Storage.shared.addSources(repos: repositories) { error in
+					if let error {
+						_isImporting = false
+						UIAlertController.showAlertWithOk(
+							title: .localized("Error"),
+							message: error.localizedDescription
+						)
+					} else {
+						competion()
+					}
 				}
 			}
 		}

--- a/Ksign/Views/Sources/SourcesCellView.swift
+++ b/Ksign/Views/Sources/SourcesCellView.swift
@@ -11,7 +11,12 @@ import NukeUI
 
 // MARK: - View
 struct SourcesCellView: View {
+	@ObservedObject private var _intelligence = SourceIntelligenceManager.shared
 	var source: AltSource
+
+	private var _insight: SourceInsight {
+		_intelligence.insight(for: source)
+	}
 	
 	// MARK: Body
 	var body: some View {
@@ -20,6 +25,21 @@ struct SourcesCellView: View {
 			subtitle: source.sourceURL?.absoluteString ?? "",
 			iconUrl: source.iconURL
 		)
+		.overlay(alignment: .bottomTrailing) {
+			HStack(spacing: 4) {
+				if _insight.isFavorite {
+					Image(systemName: "star.fill")
+						.foregroundStyle(.yellow)
+				}
+				Image(systemName: _insight.health.icon)
+					.foregroundStyle(_healthColor)
+				if _insight.updateCount > 0 {
+					Text(_insight.updateCount.description)
+						.foregroundStyle(.orange)
+				}
+			}
+			.font(.caption)
+		}
 		.swipeActions {
 			_actions(for: source)
 			_contextActions(for: source)
@@ -43,8 +63,23 @@ extension SourcesCellView {
 	
 	@ViewBuilder
 	private func _contextActions(for source: AltSource) -> some View {
+		Button(
+			_insight.isFavorite ? .localized("Remove Favorite") : .localized("Favorite"),
+			systemImage: _insight.isFavorite ? "star.slash" : "star"
+		) {
+			_intelligence.toggleFavorite(source)
+		}
 		Button(.localized("Copy"), systemImage: "doc.on.clipboard") {
 			UIPasteboard.general.string = source.sourceURL?.absoluteString
+		}
+	}
+
+	private var _healthColor: Color {
+		switch _insight.health {
+		case .healthy: return .green
+		case .degraded: return .orange
+		case .offline: return .red
+		case .unchecked: return .secondary
 		}
 	}
 }

--- a/Ksign/Views/Sources/SourcesView.swift
+++ b/Ksign/Views/Sources/SourcesView.swift
@@ -79,6 +79,11 @@ struct SourcesView: View {
                 }
             }
             .toolbar {
+				NavigationLink {
+					SourceIntelligenceView()
+				} label: {
+					Image(systemName: "chart.line.uptrend.xyaxis")
+				}
 				NBToolbarButton(
 					systemImage: "plus",
 					style: .icon,

--- a/Ksign/Views/Sources/SourcesViewModel.swift
+++ b/Ksign/Views/Sources/SourcesViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import AltSourceKit
+import CoreData
 import SwiftUI
 import NimbleJSON
 
@@ -18,64 +19,120 @@ final class SourcesViewModel: ObservableObject {
 	
 	private let _dataService = NBFetchService()
 	
-	var isFinished = true
+	@Published var isFinished = true
 	@Published var sources: [AltSource: ASRepository] = [:]
 	
 	func fetchSources(_ sources: FetchedResults<AltSource>, refresh: Bool = false, batchSize: Int = 4) async {
-		guard isFinished else { return }
-		
-		// check if sources to be fetched are the same as before, if yes, return
-		// also skip check if refresh is true
-		if !refresh, sources.allSatisfy({ self.sources[$0] != nil }) { return }
-		
-		// isfinished is used to prevent multiple fetches at the same time
-		isFinished = false
-		defer { isFinished = true }
-		
-		await MainActor.run {
+		let preparation = await MainActor.run {
+			() -> ([(objectID: NSManagedObjectID, url: URL?)], [NSManagedObjectID: AltSource])? in
+			guard self.isFinished else { return nil }
+
+			// Check if sources to be fetched are the same as before, unless a refresh was requested.
+			if !refresh, sources.allSatisfy({ self.sources[$0] != nil }) {
+				return nil
+			}
+
+			self.isFinished = false
 			self.sources = [:]
+			SourceIntelligenceManager.shared.prepareForRefresh()
+
+			let sourceArray = Array(sources)
+			let requests = sourceArray.map { (objectID: $0.objectID, url: $0.sourceURL) }
+			let sourcesByID = Dictionary(uniqueKeysWithValues: sourceArray.map { ($0.objectID, $0) })
+			return (requests, sourcesByID)
 		}
+		guard let (sourceRequests, sourcesByID) = preparation else { return }
+
+		let refreshJob = JobsManager.shared.start(
+			kind: .sourceRefresh,
+			title: .localized("Refreshing Sources"),
+			detail: .localized("Preparing")
+		)
+
+		let effectiveBatchSize = max(batchSize, 1)
+		var completedCount = 0
+		var successCount = 0
+		let dataService = _dataService
 		
-		let sourcesArray = Array(sources)
-		
-		for startIndex in stride(from: 0, to: sourcesArray.count, by: batchSize) {
-			let endIndex = min(startIndex + batchSize, sourcesArray.count)
-			let batch = sourcesArray[startIndex..<endIndex]
+		for startIndex in stride(from: 0, to: sourceRequests.count, by: effectiveBatchSize) {
+			let endIndex = min(startIndex + effectiveBatchSize, sourceRequests.count)
+			let batch = sourceRequests[startIndex..<endIndex]
 			
-			let batchResults = await withTaskGroup(of: (AltSource, ASRepository?).self, returning: [AltSource: ASRepository].self) { group in
-				for source in batch {
+			let batchResults = await withTaskGroup(
+				of: (NSManagedObjectID, ASRepository?, String?).self,
+				returning: [(NSManagedObjectID, ASRepository?, String?)].self
+			) { group in
+				for request in batch {
+					let objectID = request.objectID
+					let url = request.url
 					group.addTask {
-						guard let url = source.sourceURL else {
-							return (source, nil)
+						guard let url else {
+							return (objectID, nil, String.localized("Missing source URL"))
 						}
 						
 						return await withCheckedContinuation { continuation in
-							self._dataService.fetch(from: url) { (result: RepositoryDataHandler) in
+							dataService.fetch(from: url) { (result: RepositoryDataHandler) in
 								switch result {
 								case .success(let repo):
-									continuation.resume(returning: (source, repo))
-								case .failure(_):
-									continuation.resume(returning: (source, nil))
+									continuation.resume(returning: (objectID, repo, nil))
+								case .failure(let error):
+									continuation.resume(returning: (objectID, nil, error.localizedDescription))
 								}
 							}
 						}
 					}
 				}
 				
-				var results = [AltSource: ASRepository]()
-				for await (source, repo) in group {
-					if let repo {
-						results[source] = repo
-					}
+				var results: [(NSManagedObjectID, ASRepository?, String?)] = []
+				for await result in group {
+					results.append(result)
 				}
 				return results
 			}
-			
-			await MainActor.run {
-				for (source, repo) in batchResults {
-					self.sources[source] = repo
+
+			completedCount += batchResults.count
+			successCount += batchResults.reduce(into: 0) { count, result in
+				if result.1 != nil {
+					count += 1
 				}
 			}
+			
+			await MainActor.run {
+				for (objectID, repo, errorMessage) in batchResults {
+					guard let source = sourcesByID[objectID] else { continue }
+					if let repo {
+						self.sources[source] = repo
+						SourceIntelligenceManager.shared.recordSuccess(source: source, repository: repo)
+					} else {
+						SourceIntelligenceManager.shared.recordFailure(
+							source: source,
+							message: errorMessage ?? String.localized("Unknown source error")
+						)
+					}
+				}
+				JobsManager.shared.update(
+					refreshJob,
+					progress: sourceRequests.isEmpty ? 1 : Double(completedCount) / Double(sourceRequests.count),
+					detail: String.localized("%lld of %lld sources", arguments: completedCount, sourceRequests.count)
+				)
+			}
+		}
+
+		if successCount == 0, !sourceRequests.isEmpty {
+			JobsManager.shared.fail(
+				refreshJob,
+				message: .localized("No sources could be refreshed."),
+				detail: .localized("Source refresh failed")
+			)
+		} else {
+			JobsManager.shared.complete(
+				refreshJob,
+				detail: String.localized("%lld sources refreshed", arguments: successCount)
+			)
+		}
+
+		await MainActor.run {
+			self.isFinished = true
 		}
 	}
 }

--- a/Ksign/Views/TabView/TabEnum.swift
+++ b/Ksign/Views/TabView/TabEnum.swift
@@ -24,7 +24,7 @@ enum TabEnum: String, CaseIterable, Hashable {
 		case .settings: 	return .localized("Settings")
 		case .certificates:	return .localized("Certificates")
 		case .appstore: 	return .localized("App Store")
-        case .downloader:   return .localized("Downloads")
+        case .downloader:   return .localized("Jobs")
 		}
 	}
 	
@@ -36,7 +36,7 @@ enum TabEnum: String, CaseIterable, Hashable {
 		case .settings: 	return "gearshape.2"
 		case .certificates: return "person.text.rectangle"
 		case .appstore: 	return "plus.app.fill"
-        case .downloader:    return "square.and.arrow.down.fill"
+        case .downloader:    return "clock.arrow.circlepath"
 		}
 	}
 	
@@ -49,7 +49,7 @@ enum TabEnum: String, CaseIterable, Hashable {
 		case .settings: SettingsView()
 		case .certificates: NBNavigationView(.localized("Certificates")) { CertificatesView() }
 		case .appstore: AppstoreView()
-        case .downloader: DownloaderView()
+        case .downloader: JobsView()
 		}
 	}
 	

--- a/KsignTests/ARArchiveTests.swift
+++ b/KsignTests/ARArchiveTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Ksign
+
+final class ARArchiveTests: XCTestCase {
+	func testRejectsTruncatedHeader() async throws {
+		let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		var data = Data("!<arch>\n".utf8)
+		data.append(Data(repeating: 0, count: 10))
+		try data.write(to: url)
+
+		do {
+			let archive = try AR(with: url)
+			_ = try await archive.extract()
+			XCTFail("Expected the truncated archive to be rejected")
+		} catch let error as ARError {
+			XCTAssertEqual(error.errorDescription, "Invalid AR archive: Truncated file header")
+		}
+	}
+
+	func testAllowsZeroLengthMember() async throws {
+		let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		var data = Data("!<arch>\n".utf8)
+		data.append(_field("empty/", length: 16))
+		data.append(_field("0", length: 12))
+		data.append(_field("0", length: 6))
+		data.append(_field("0", length: 6))
+		data.append(_field("0", length: 8))
+		data.append(_field("0", length: 10))
+		data.append(Data("`\n".utf8))
+		try data.write(to: url)
+
+		let archive = try AR(with: url)
+		let files = try await archive.extract()
+
+		XCTAssertEqual(files.count, 1)
+		XCTAssertEqual(files.first?.name, "empty")
+		XCTAssertEqual(files.first?.size, 0)
+	}
+
+	private func _field(_ value: String, length: Int) -> Data {
+		let padded = value.padding(toLength: length, withPad: " ", startingAt: 0)
+		return Data(padded.prefix(length).utf8)
+	}
+}

--- a/KsignTests/ArchivePathValidatorTests.swift
+++ b/KsignTests/ArchivePathValidatorTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import Ksign
+
+final class ArchivePathValidatorTests: XCTestCase {
+	func testAllowsNestedPathInsideDestination() throws {
+		let base = URL(fileURLWithPath: "/tmp/KsignArchiveTest", isDirectory: true)
+		let destination = try ArchivePathValidator.destinationURL(
+			base: base,
+			entryPath: "Payload/Test.app/Info.plist"
+		)
+
+		XCTAssertTrue(destination.path.hasPrefix(base.path))
+	}
+
+	func testRejectsParentTraversal() {
+		let base = URL(fileURLWithPath: "/tmp/KsignArchiveTest", isDirectory: true)
+
+		XCTAssertThrowsError(
+			try ArchivePathValidator.destinationURL(base: base, entryPath: "../../outside")
+		)
+	}
+
+	func testRejectsAbsolutePath() {
+		let base = URL(fileURLWithPath: "/tmp/KsignArchiveTest", isDirectory: true)
+
+		XCTAssertThrowsError(
+			try ArchivePathValidator.destinationURL(base: base, entryPath: "/private/outside")
+		)
+	}
+
+	func testRejectsBackslashTraversal() {
+		let base = URL(fileURLWithPath: "/tmp/KsignArchiveTest", isDirectory: true)
+
+		XCTAssertThrowsError(
+			try ArchivePathValidator.destinationURL(base: base, entryPath: #"Payload\..\..\outside"#)
+		)
+	}
+}

--- a/KsignTests/OptionsMigrationTests.swift
+++ b/KsignTests/OptionsMigrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import Ksign
+
+final class OptionsMigrationTests: XCTestCase {
+	func testMissingNewPropertiesUseDefaultsWithoutResettingSavedValues() throws {
+		let encoded = try JSONEncoder().encode(Options.defaultOptions)
+		var json = try XCTUnwrap(
+			JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+		)
+		json.removeValue(forKey: "removeSupportedDevices")
+		json["ppqProtection"] = false
+
+		let oldData = try JSONSerialization.data(withJSONObject: json)
+		let migrated = try XCTUnwrap(OptionsManager.decodeOptionsMergingDefaults(oldData))
+
+		XCTAssertTrue(migrated.removeSupportedDevices)
+		XCTAssertFalse(migrated.ppqProtection)
+	}
+}

--- a/KsignTests/SourceIntelligenceTests.swift
+++ b/KsignTests/SourceIntelligenceTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import Ksign
+
+final class SourceIntelligenceTests: XCTestCase {
+	func testOnlyNewerSourceVersionIsAnUpdate() {
+		XCTAssertTrue(
+			SourceIntelligenceManager.isNewerVersion("2.0", than: ["1.9"])
+		)
+		XCTAssertFalse(
+			SourceIntelligenceManager.isNewerVersion("1.9", than: ["2.0"])
+		)
+		XCTAssertFalse(
+			SourceIntelligenceManager.isNewerVersion("2.0", than: ["1.0", "2.0"])
+		)
+	}
+}

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ TMP := $(TMPDIR)/$(NAME)
 STAGE := $(TMP)/stage
 APP := $(TMP)/Build/Products/Release-$(PLATFORM)
 
-.PHONY: all clean $(SCHEMES)
+.PHONY: all clean test $(SCHEMES)
 
 all: $(SCHEMES)
 
@@ -13,6 +13,14 @@ clean:
 	rm -rf "$(TMP)"
 	rm -rf packages
 	rm -rf Payload
+
+test:
+	xcodebuild \
+	    -project Ksign.xcodeproj \
+	    -scheme FeatherTests \
+	    -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16 Pro' \
+	    CODE_SIGNING_ALLOWED=NO \
+	    test
 
 deps:
 	rm -rf deps || true


### PR DESCRIPTION
This PR adds two major app improvements:

- **Source Intelligence**: a new source dashboard with health, trust, favorites, update detection, content-change tracking, and built-in source recovery.
- **Unified Jobs Center**: a persistent activity center for downloads, imports, signing, extraction, archiving, installation, source refreshes, and certificate imports.

It also includes reliability, security, and persistence hardening around archives, certificate storage, Core Data saves, installer startup, and crash-prone force unwraps.

## Changes

- Added persistent `JobsManager` and `JobsView`.
- Replaced the old Downloads tab entry with a Jobs Center while still keeping access to Downloads.
- Added `SourceIntelligenceManager` and `SourceIntelligenceView`.
- Added source health/trust/favorite/update badges in source and source app lists.
- Added update detection using installed imported/signed app versions.
- Added Keychain-backed certificate password storage with legacy migration.
- Added UUID-based certificate selection with legacy index migration.
- Hardened ZIP/TAR/DEB/AR extraction against unsafe paths, symlinks, malformed headers, and traversal.
- Improved signing flow error handling and bulk signing progress/error reporting.
- Made app import/sign/certificate database writes report real save failures and clean up orphaned files.
- Improved installer startup so the local server only starts when required.
- Added storage-load error surfacing in the app UI.
- Added focused tests for archive path validation, AR archive parsing, options migration, and source version comparison.
- Updated CI to run tests before the beta build.

## Testing

Verified locally with static checks:

- `git diff --check`
- Swift delimiter/structure scan across all Swift files
- crash-prone force-pattern scan
- project/test scheme XML and test target wiring checks

Added tests:

- `ArchivePathValidatorTests`
- `ARArchiveTests`
- `OptionsMigrationTests`
- `SourceIntelligenceTests`
